### PR TITLE
add season tag-> number conversion file

### DIFF
--- a/data/seasons/d2-season-info.js
+++ b/data/seasons/d2-season-info.js
@@ -3,6 +3,7 @@ module.exports = {
     1: {
       DLCName: 'Red War',
       seasonName: 'Red War',
+      seasonTag: 'redwar',
       season: 1,
       year: 1,
       maxLevel: 20,
@@ -14,6 +15,7 @@ module.exports = {
     2: {
       DLCName: 'Curse of Osiris',
       seasonName: 'Curse of Osiris',
+      seasonTag: 'osiris',
       season: 2,
       year: 1,
       maxLevel: 25,
@@ -25,6 +27,7 @@ module.exports = {
     3: {
       DLCName: 'Warmind',
       seasonName: 'Warmind',
+      seasonTag: 'warmind',
       season: 3,
       year: 1,
       maxLevel: 30,
@@ -36,6 +39,7 @@ module.exports = {
     4: {
       DLCName: 'Forsaken',
       seasonName: 'Season of the Outlaw',
+      seasonTag: 'outlaw',
       season: 4,
       year: 2,
       maxLevel: 50,
@@ -47,6 +51,7 @@ module.exports = {
     5: {
       DLCName: 'Black Armory',
       seasonName: 'Season of the Forge',
+      seasonTag: 'forge',
       season: 5,
       year: 2,
       maxLevel: 50,
@@ -58,6 +63,7 @@ module.exports = {
     6: {
       DLCName: "Joker's Wild",
       seasonName: 'Season of the Drifter',
+      seasonTag: 'drifter',
       season: 6,
       year: 2,
       maxLevel: 50,
@@ -69,6 +75,7 @@ module.exports = {
     7: {
       DLCName: 'Penumbra',
       seasonName: 'Season of Opulence',
+      seasonTag: 'opulence',
       season: 7,
       year: 2,
       maxLevel: 50,
@@ -80,6 +87,7 @@ module.exports = {
     8: {
       DLCName: 'Shadowkeep',
       seasonName: 'Season of the Undying',
+      seasonTag: 'undying',
       season: 8,
       year: 3,
       maxLevel: 50,
@@ -91,6 +99,7 @@ module.exports = {
     9: {
       DLCName: '',
       seasonName: 'Season of Dawn',
+      seasonTag: 'dawn',
       season: 9,
       year: 3,
       maxLevel: 50,

--- a/generate-season-info.js
+++ b/generate-season-info.js
@@ -1,5 +1,6 @@
 const { getCurrentSeason, writeFile, getMostRecentManifest } = require('./helpers.js');
 const seasons = require('./data/seasons/seasons_master.json');
+const seasonsInfo = require('./data/seasons/d2-season-info.js').D2SeasonInfo;
 
 const calculatedSeason = getCurrentSeason();
 
@@ -17,3 +18,10 @@ Object.keys(inventoryItem).forEach(function(key) {
 });
 
 writeFile('./data/seasons/seasons_master.json', seasons);
+
+const seasonTags = Object.values(seasonsInfo)
+  .filter((seasonInfo) => seasonInfo.season <= calculatedSeason)
+  .map((seasonInfo) => [seasonInfo.seasonTag, seasonInfo.season])
+  .reduce((acc, [tag, num]) => ((acc[tag] = num), acc), {});
+
+writeFile('./output/season-tags.json', seasonTags);

--- a/output/season-tags.json
+++ b/output/season-tags.json
@@ -1,0 +1,9 @@
+{
+  "redwar": 1,
+  "osiris": 2,
+  "warmind": 3,
+  "outlaw": 4,
+  "forge": 5,
+  "drifter": 6,
+  "opulence": 7
+}


### PR DESCRIPTION
merge after
https://github.com/DestinyItemManager/DIM/pull/4261

adds a season shortname and creates a JSON to convert that to a number
consider maybe expansion names too? or will that need to change in the future.... still unclear but time will tell