### PR TITLE
update season enums

### DIFF
--- a/data/seasons/d2-season-info.ts
+++ b/data/seasons/d2-season-info.ts
@@ -10,7 +10,7 @@ export enum D2SeasonEnum {
   SHADOWKEEP,
   DAWN,
   WORTHY,
-  REDACTED_11, // TODO: Update on verification
+  ARRIVAL,
   REDACTED_12, // TODO: Update on verification
 
   __LENGTH__, // This always needs to be last

--- a/output/d2-season-info.ts
+++ b/output/d2-season-info.ts
@@ -10,7 +10,7 @@ export enum D2SeasonEnum {
   SHADOWKEEP,
   DAWN,
   WORTHY,
-  REDACTED_11, // TODO: Update on verification
+  ARRIVAL,
   REDACTED_12, // TODO: Update on verification
 
   __LENGTH__, // This always needs to be last


### PR DESCRIPTION
Closes #180 

Do we have an official name of the season that launches with `Beyond Light`?