### PR TITLE
add searchString in favor of removing duplicated code from missing-so…

### DIFF
--- a/data/sources/categories.json
+++ b/data/sources/categories.json
@@ -80,7 +80,13 @@
         "Wish-Ender",
         "The Eternal Return"
       ],
-      "searchString": "source:shatteredthrone or source:pit or source:prophecy or source:presage or source:harbinger"
+      "searchString": [
+        "shatteredthrone",
+        "pit",
+        "prophecy",
+        "presage",
+        "harbinger"
+      ]
     },
     "edz": { "includes": ["European Dead Zone", "edz"] },
     "eow": { "includes": ["Eater of Worlds raid"] },
@@ -199,7 +205,16 @@
         "Shadow of Earth Shell",
         "Divinity"
       ],
-      "searchString": "source:crownofsorrow or source:deepstonecrypt or source:eow or source:garden or source:lastwish or source:leviathan or source:scourge or source:sos"
+      "searchString": [
+        "crownofsorrow",
+        "deepstonecrypt",
+        "eow",
+        "garden",
+        "lastwish",
+        "leviathan",
+        "scourge",
+        "sos"
+      ]
     },
     "scourge": {
       "includes": ["Scourge"],
@@ -299,7 +314,14 @@
         "promotional",
         "Handed out"
       ],
-      "searchString": "is:dawning or is:crimsondays or is:solstice or is:fotl or is:revelry or is:games"
+      "searchString": [
+        "dawning",
+        "crimsondays",
+        "solstice",
+        "fotl",
+        "revelry",
+        "games"
+      ]
     },
     "battlegrounds": { "includes": ["Battlegrounds"] },
     "wartable": { "includes": ["War Table", "Challenger's Proving VII Quest"] },
@@ -413,7 +435,20 @@
         "Imperial Opulence",
         "Shadow of Earth Shell"
       ],
-      "searchString": "source:mercury or source:mars or source:titan or source:io or source:leviathan or source:ep or source:blackarmory or source:menagerie or source:eow or source:sos or source:scourge or source:crownofsorrow"
+      "searchString": [
+        "mercury",
+        "mars",
+        "titan",
+        "io",
+        "leviathan",
+        "ep",
+        "blackarmory",
+        "menagerie",
+        "eow",
+        "sos",
+        "scourge",
+        "crownofsorrow"
+      ]
     },
     "ignore": {
       "includes": [

--- a/data/sources/categories.json
+++ b/data/sources/categories.json
@@ -79,7 +79,8 @@
         "Pallas Galliot",
         "Wish-Ender",
         "The Eternal Return"
-      ]
+      ],
+      "searchString": "source:shatteredthrone or source:pit or source:prophecy or source:presage or source:harbinger"
     },
     "edz": { "includes": ["European Dead Zone", "edz"] },
     "eow": { "includes": ["Eater of Worlds raid"] },
@@ -185,6 +186,7 @@
     "nightmare": { "includes": ["nightmare"] },
     "nm": { "includes": ["Executor Hideo"] },
     "prestige": { "includes": ["Prestige difficulty"] },
+    "pit": { "includes": ["Pit of Heresy"] },
     "prophecy": { "includes": ["Season of Arrivals dungeon"] },
     "raid": {
       "includes": ["raid", "Guide", "Guided", "Not a Scratch", "Rock Bottom"],
@@ -194,8 +196,10 @@
         "Dreaming Spectrum",
         "Imperial Opulence",
         "Midnight Smith",
-        "Shadow of Earth Shell"
-      ]
+        "Shadow of Earth Shell",
+        "Divinity"
+      ],
+      "searchString": "source:crownofsorrow or source:deepstonecrypt or source:eow or source:garden or source:lastwish or source:leviathan or source:scourge or source:sos"
     },
     "scourge": {
       "includes": ["Scourge"],
@@ -294,7 +298,8 @@
         "End-of-Season",
         "promotional",
         "Handed out"
-      ]
+      ],
+      "searchString": "is:dawning or is:crimsondays or is:solstice or is:fotl or is:revelry or is:games"
     },
     "battlegrounds": { "includes": ["Battlegrounds"] },
     "wartable": { "includes": ["War Table", "Challenger's Proving VII Quest"] },
@@ -347,6 +352,69 @@
     "harbinger": { "includes": ["Let Loose Thy Talons"] },
     "lostsectors": { "includes": ["Lost Sectors"] },
     "umbral": { "includes": ["Umbral", "Recaster"] },
+    "dcv": {
+      "includes": [
+        "mercury",
+        "A Garden World",
+        "Tree of Probabilities",
+        "on Mars",
+        "Will of the Thousands",
+        "Strange Terrain",
+        "Saturn's moon, Titan",
+        "Savathûn's Song",
+        "on io",
+        "The Pyramidion",
+        "leviathan",
+        "menagerie",
+        "crown of sorrow",
+        "Escalation Protocol",
+        "Defeat 25 Final Bosses",
+        "Eater of Worlds raid",
+        "Spire of Stars raid",
+        "forge ignition",
+        "glyph puzzle",
+        "Black armory",
+        "Obsidian Accelerator",
+        "Reunited Siblings",
+        "Master Blaster",
+        "Clean Up on Aisle Five",
+        "Beautiful but Deadly",
+        "Master Smith",
+        "Scourge",
+        "crown of sorrow"
+      ],
+      "excludes": [
+        "chalice"
+      ],
+      "items": [
+        "The Tribute Hall",
+        "3580904580",
+        "Bad Juju",
+        "Árma Mákhēs",
+        "A Hall of Delights",
+        "Cinderchar",
+        "Golden Empire",
+        "Goldleaf",
+        "The Emperor's Chosen",
+        "The Imperial Menagerie",
+        "Shadow Gilt",
+        "Bergusian Night",
+        "House of Meyrin",
+        "Izanagi's Burden",
+        "Jötunn",
+        "Le Monarque",
+        "New Age Black Armory",
+        "Rasmussen Clan",
+        "Refurbished Black Armory",
+        "Satou Tribe",
+        "Midnight Smith",
+        "Crown of Sorrow",
+        "Imperial Dress",
+        "Imperial Opulence",
+        "Shadow of Earth Shell"
+      ],
+      "searchString": "source:mercury or source:mars or source:titan or source:io or source:leviathan or source:ep or source:blackarmory or source:menagerie or source:eow or source:sos or source:scourge or source:crownofsorrow"
+    },
     "ignore": {
       "includes": [
         "Forging Your Own Path",

--- a/output/missing-source-info.ts
+++ b/output/missing-source-info.ts
@@ -631,6 +631,284 @@ const missingSources: { [key: string]: number[] } = {
     4211218181, // Ankaa Seeker IV
     4269346472, // Binary Phoenix Bond
   ],
+  dcv: [
+    4450861, // Shadow's Greaves
+    36900384, // Opulent Scholar Gloves
+    60076357, // Opulent Scholar Bond
+    61987238, // Kairos Function Mask
+    64543268, // Boots of the Emperor's Minister
+    64543269, // Boots of the Fulminator
+    66047450, // Lost Pacific Gloves
+    75025442, // Boots of Feltroc
+    78664642, // Annealed Shaper Gloves
+    80067121, // Opulent Stalker Vest
+    88873628, // Gauntlets of Nohr
+    91896851, // Equitis Shade Boots
+    96643258, // Bladesmith's Memory Mask
+    133093143, // Forged Machinist Greaves
+    161336786, // Mask of Sekris
+    165966230, // Insigne Shade Gloves
+    256904954, // Shadow's Grips
+    300528205, // Bladesmith's Memory Vest
+    308676790, // Opulent Stalker Mask
+    311429764, // Shadow's Mark
+    311429765, // Mark of the Emperor's Champion
+    325125949, // Shadow's Helm
+    325434398, // Vest of the Ace-Defiant
+    325434399, // Vest of the Emperor's Agent
+    326149062, // Shadow's Mask
+    336656482, // Boots of the Fulminator
+    336656483, // Boots of the Emperor's Minister
+    384384821, // Bladesmith's Memory Strides
+    425390008, // Midnight Exigent Greaves
+    452177303, // Kairos Function Crown
+    455108040, // Helm of the Emperor's Champion
+    455108041, // Mask of Rull
+    503773817, // Insigne Shade Gloves
+    508035927, // Midnight Exigent Helm
+    563606995, // Woven Firesmith Boots
+    574916072, // Bond of Sekris
+    581908796, // Bond of the Emperor's Minister
+    581908797, // Shadow's Bond
+    583145321, // Gunsmith's Devotion Crown
+    588627781, // Bond of Sekris
+    608074492, // Robes of the Emperor's Minister
+    608074493, // Robes of the Fulminator
+    612065993, // Penumbral Mark
+    618662448, // Headpiece of the Emperor's Minister
+    618662449, // Mask of the Fulminator
+    620774353, // BrayTech Sn0Mask
+    627690043, // Wraps of Sekris
+    631885885, // Gensym Knight Cuirass
+    641933202, // Helm of the Ace-Defiant
+    641933203, // Mask of the Emperor's Agent
+    648456777, // Opulent Stalker Strides
+    688564517, // Lost Pacific Vest
+    720656969, // Yuga Sundown Robes
+    727401524, // Lost Pacific Mark
+    748485514, // Mask of the Fulminator
+    748485515, // Headpiece of the Emperor's Minister
+    754149842, // Wraps of the Emperor's Minister
+    754149843, // Wraps of the Fulminator
+    781488881, // Mask of Feltroc
+    813277303, // Equitis Shade Rig
+    815611257, // Gensym Knight Plate
+    845536715, // Vest of Feltroc
+    853543290, // Greaves of Rull
+    853543291, // Greaves of the Emperor's Champion
+    874272413, // Shadow's Robes
+    884481817, // Kairos Function Boots
+    917591018, // Grips of the Ace-Defiant
+    917591019, // Gloves of the Emperor's Agent
+    935022405, // Opulent Duelist Greaves
+    940003738, // Gunsmith's Devotion Boots
+    942205921, // Shadow's Vest
+    977326564, // Bulletsmith's Ire Mark
+    1005587287, // BrayTech Researcher's Gloves
+    1035112834, // Turris Shade Mark
+    1107067065, // Shadow's Strides
+    1108389626, // Gloves of the Emperor's Agent
+    1108389627, // Grips of the Ace-Defiant
+    1117243014, // Woven Firesmith Cape
+    1129634130, // Shadow's Helm
+    1156439528, // Insigne Shade Cover
+    1178920188, // Turris Shade Helm
+    1194507306, // Opulent Duelist Helm
+    1200068467, // Opulent Duelist Gauntlets
+    1230192768, // Robes of the Fulminator
+    1230192769, // Robes of the Emperor's Minister
+    1256688732, // Mask of Feltroc
+    1319515713, // Penumbral Bond
+    1322519316, // Lost Pacific Boots
+    1339632007, // Turris Shade Helm
+    1354679720, // Shadow's Cloak
+    1354679721, // Cloak of the Emperor's Agent
+    1378348656, // Insigne Shade Boots
+    1390282760, // Chassis of Rull
+    1390282761, // Cuirass of the Emperor's Champion
+    1421936449, // BrayTech Absolute Zero Mark
+    1445420672, // Mindbreaker Boots
+    1471193607, // Opulent Stalker Grips
+    1497164220, // Forged Machinist Helm
+    1499503877, // Gunsmith's Devotion Bond
+    1505338369, // Lost Pacific Greaves
+    1511235307, // Lost Pacific Grips
+    1512129090, // Forged Machinist Mark
+    1558884814, // Lost Pacific Helm
+    1589569999, // Songbreaker Gauntlets
+    1595987387, // Shadow's Gauntlets
+    1743790315, // Lost Pacific Helmet
+    1752028469, // Gensym Knight Bond
+    1756558505, // Mask of Sekris
+    1793869832, // Turris Shade Greaves
+    1877424533, // Robes of Sekris
+    1886391430, // Songbreaker Gloves
+    1908254109, // Opulent Duelist Plate
+    1934647691, // Shadow's Mask
+    1937834292, // Shadow's Strides
+    1989682895, // Bulletsmith's Ire Gauntlets
+    1991627398, // BrayTech Researcher's Hood
+    2025523685, // Mindbreaker Boots
+    2032088577, // Gensym Knight Greaves
+    2034926084, // Yuga Sundown Bond
+    2070062384, // Shadow's Bond
+    2070062385, // Bond of the Emperor's Minister
+    2085635022, // Gensym Knight Helm
+    2104205416, // Penumbral Mark
+    2114894938, // Abhorrent Imperative Grasps
+    2119727155, // Annealed Shaper Crown
+    2122810492, // Annealed Shaper Boots
+    2128823667, // Turris Shade Mark
+    2135450480, // Gensym Knight Cloak
+    2149271612, // Penumbral Cloak
+    2153222031, // Shadow's Gloves
+    2158603584, // Gauntlets of Rull
+    2158603585, // Gauntlets of the Emperor's Champion
+    2164070257, // Mindbreaker Boots
+    2171693954, // Lost Pacific Mask
+    2183861870, // Gauntlets of the Emperor's Champion
+    2183861871, // Gauntlets of Rull
+    2232730708, // Vest of the Emperor's Agent
+    2232730709, // Vest of the Ace-Defiant
+    2245491369, // Opulent Scholar Hood
+    2275496908, // Opulent Stalker Cloak
+    2286640864, // Gunsmith's Devotion Gloves
+    2287801693, // BrayTech Winter Cloak
+    2290569619, // Songbreaker Grips
+    2295412715, // Turris Shade Plate
+    2305801487, // Insigne Shade Cover
+    2320951982, // Abhorrent Imperative Vest
+    2334017923, // Bladesmith's Memory Grips
+    2369496221, // Plate of Nohr
+    2395959535, // Yuga Sundown Gloves
+    2472794149, // Shadow's Mind
+    2475562438, // Equitis Shade Cloak
+    2507934309, // Gensym Knight Strides
+    2529023928, // Kairos Function Mark
+    2537874394, // Boots of Sekris
+    2552158692, // Equitis Shade Rig
+    2554337844, // Gensym Knight Mark
+    2564183153, // Bulletsmith's Ire Greaves
+    2575374197, // Turris Shade Gauntlets
+    2584088255, // Lost Pacific Gauntlets
+    2602992893, // Lost Pacific Strides
+    2620001759, // Insigne Shade Robes
+    2639046519, // Abhorrent Imperative Cloak
+    2652946280, // Opulent Scholar Robes
+    2653039573, // Grips of Feltroc
+    2672101104, // Gensym Knight Gloves
+    2673599019, // Kairos Function Gauntlets
+    2719710110, // Bulletsmith's Ire Helm
+    2722103686, // Equitis Shade Boots
+    2725842378, // Gensym Knight Casque
+    2748513874, // Kairos Function Robes
+    2750983488, // Bladesmith's Memory Cloak
+    2758465168, // Greaves of the Emperor's Champion
+    2758465169, // Greaves of Rull
+    2769298993, // Shadow's Boots
+    2772980243, // Gensym Knight Grips
+    2814122105, // BrayTech Researcher's Boots
+    2851938357, // Forged Machinist Gauntlets
+    2904930850, // Turris Shade Plate
+    2913992254, // Mask of Rull
+    2913992255, // Helm of the Emperor's Champion
+    2938125956, // Plate of Nohr
+    2970562833, // Yuga Sundown Boots
+    2989159626, // Gensym Knight Boots
+    3026807258, // Opulent Scholar Boots
+    3066613133, // Equitis Shade Cowl
+    3082625196, // Shadow's Gauntlets
+    3092380260, // Mark of the Emperor's Champion
+    3092380261, // Shadow's Mark
+    3099636805, // Greaves of Nohr
+    3108321700, // Penumbral Bond
+    3110838463, // Gensym Knight Gauntlets
+    3126089918, // Yuga Sundown Helmet
+    3155412907, // Forged Machinist Plate
+    3158739321, // Gensym Knight Hood
+    3168014845, // Cloak of Feltroc
+    3181497704, // Robes of Sekris
+    3188870561, // BrayTech Researcher's Robes
+    3211894260, // Shadow's Gloves
+    3240387365, // BrayTech Sn0Helm
+    3283642233, // Lost Pacific Plate
+    3283890999, // Woven Firesmith Vest
+    3292127944, // Cuirass of the Emperor's Champion
+    3292127945, // Chassis of Rull
+    3316476193, // Equitis Shade Grips
+    3322192806, // Annealed Shaper Robes
+    3331120813, // Boots of Sekris
+    3333954498, // Kairos Function Helm
+    3349283422, // Shadow's Mind
+    3356534040, // Gensym Knight Robes
+    3359121706, // Mask of Nohr
+    3360543264, // BrayTech Combat Vest
+    3363625697, // Woven Firesmith Grips
+    3364682867, // Gauntlets of Nohr
+    3370242000, // Opulent Duelist Mark
+    3370914423, // Kairos Function Grips
+    3371366804, // Abhorrent Imperative Strides
+    3381758732, // Shadow's Robes
+    3385331555, // Kairos Function Bond
+    3386768934, // Greaves of Nohr
+    3395856235, // Insigne Shade Boots
+    3406713877, // Shadow's Plate
+    3416618798, // Lost Pacific Robes
+    3469837505, // Kairos Function Vest
+    3484179468, // BrayTech Iron-Heart Engine
+    3491990569, // Bulletsmith's Ire Plate
+    3497220322, // Cloak of Feltroc
+    3499632894, // Shadow's Boots
+    3517729518, // Shadow's Vest
+    3518193943, // Penumbral Cloak
+    3518692432, // Equitis Shade Cowl
+    3530284424, // Wraps of the Fulminator
+    3530284425, // Wraps of the Emperor's Minister
+    3573869992, // BrayTech Survival Mitts
+    3581198350, // Turris Shade Gauntlets
+    3607521808, // Woven Firesmith Mask
+    3681852889, // Mark of Nohr
+    3691605010, // Midnight Exigent Plate
+    3693007688, // Grips of Feltroc
+    3711700026, // Mask of the Emperor's Agent
+    3711700027, // Helm of the Ace-Defiant
+    3719175804, // Equitis Shade Grips
+    3720446265, // Equitis Shade Cloak
+    3731175213, // Mask of Nohr
+    3734713335, // Lost Pacific Bond
+    3759659288, // Shadow's Plate
+    3792637803, // Abhorrent Imperative Mask
+    3820658718, // Kairos Function Wraps
+    3831484112, // Mark of Nohr
+    3842934816, // Wraps of Sekris
+    3853397100, // Boots of the Emperor's Agent
+    3853397101, // Boots of the Ace-Defiant
+    3862230571, // Insigne Shade Bond
+    3867160430, // Insigne Shade Bond
+    3873109093, // Kairos Function Plate
+    3876414174, // Midnight Exigent Gauntlets
+    3950028838, // Cloak of the Emperor's Agent
+    3950028839, // Shadow's Cloak
+    3971375612, // BrayTech Researcher's Bond
+    3979487476, // BrayTech Thermal Grips
+    4017853847, // Shadow's Grips
+    4064641551, // Annealed Shaper Bond
+    4092373800, // Gunsmith's Devotion Robes
+    4105480824, // Lost Pacific Cape
+    4148237373, // Kairos Function Greaves
+    4151496279, // Turris Shade Greaves
+    4152814806, // Shadow's Greaves
+    4209278210, // BrayTech Sn0Treads
+    4213777114, // Insigne Shade Robes
+    4229161783, // Boots of Feltroc
+    4240041208, // Kairos Function Boots
+    4240859456, // Vest of Feltroc
+    4251770244, // Boots of the Ace-Defiant
+    4251770245, // Boots of the Emperor's Agent
+    4252342556, // Kairos Function Cloak
+    4267226110, // BrayTech Sn0Boots
+    4286845987, // Midnight Exigent Mark
+  ],
   deepstonecrypt: [],
   deluxe: [
     2683682447, // Traitor's Fate
@@ -1991,6 +2269,7 @@ const missingSources: { [key: string]: number[] } = {
     3060679667, // Sovereign Vest
     4119718816, // Sovereign Helm
   ],
+  pit: [],
   presage: [],
   prestige: [],
   prophecy: [],

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -1,5 +1,5 @@
 const D2Sources: {
-  [key: string]: { itemHashes: number[]; sourceHashes: number[]; searchString: string };
+  [key: string]: { itemHashes: number[]; sourceHashes: number[]; searchString: string[] };
 } = {
   adventure: {
     itemHashes: [],
@@ -25,14 +25,14 @@ const D2Sources: {
       3754173885, // Source: Adventure "Getting Your Hands Dirty" in the European Dead Zone.
       4214471686, // Source: Adventure "Unsafe at Any Speed" in the European Dead Zone.
     ],
-    searchString: '',
+    searchString: [],
   },
   battlegrounds: {
     itemHashes: [],
     sourceHashes: [
       3391325445, // Source: Battlegrounds
     ],
-    searchString: '',
+    searchString: [],
   },
   blackarmory: {
     itemHashes: [
@@ -68,7 +68,7 @@ const D2Sources: {
       4247521481, // Source: Complete the "Beautiful but Deadly" Triumph.
       4290227252, // Source: Complete a Volundr Forge ignition.
     ],
-    searchString: '',
+    searchString: [],
   },
   calus: {
     itemHashes: [
@@ -89,7 +89,7 @@ const D2Sources: {
       4009509410, // Source: Complete challenges in the Leviathan raid.
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
     ],
-    searchString: '',
+    searchString: [],
   },
   campaign: {
     itemHashes: [],
@@ -125,28 +125,28 @@ const D2Sources: {
       4288102251, // Requires 1,000 Titan Kills
       4290499613, // Source: Complete the campaign as a Hunter.
     ],
-    searchString: '',
+    searchString: [],
   },
   cayde6: {
     itemHashes: [],
     sourceHashes: [
       2206233229, // Source: Follow treasure maps.
     ],
-    searchString: '',
+    searchString: [],
   },
   cipher: {
     itemHashes: [],
     sourceHashes: [
       4155903822, // Source: Obtained from Master Cryptarch Rahool.
     ],
-    searchString: '',
+    searchString: [],
   },
   contact: {
     itemHashes: [],
     sourceHashes: [
       2039343154, // Source: Contact public event.
     ],
-    searchString: '',
+    searchString: [],
   },
   crownofsorrow: {
     itemHashes: [
@@ -159,7 +159,7 @@ const D2Sources: {
       2399751101, // Acquired from the raid "Crown of Sorrow."
       3147603678, // Acquired from the raid "Crown of Sorrow."
     ],
-    searchString: '',
+    searchString: [],
   },
   crucible: {
     itemHashes: [
@@ -194,7 +194,7 @@ const D2Sources: {
       2915991372, // Source: Crucible
       3656787928, // Source: Crucible Salvager's Salvo Armament
     ],
-    searchString: '',
+    searchString: [],
   },
   dcv: {
     itemHashes: [
@@ -290,8 +290,20 @@ const D2Sources: {
       4263201695, // Source: Complete Nightfall strike "A Garden World."
       4290227252, // Source: Complete a Volundr Forge ignition.
     ],
-    searchString:
-      'source:mercury or source:mars or source:titan or source:io or source:leviathan or source:ep or source:blackarmory or source:menagerie or source:eow or source:sos or source:scourge or source:crownofsorrow',
+    searchString: [
+      'mercury',
+      'mars',
+      'titan',
+      'io',
+      'leviathan',
+      'ep',
+      'blackarmory',
+      'menagerie',
+      'eow',
+      'sos',
+      'scourge',
+      'crownofsorrow',
+    ],
   },
   deepstonecrypt: {
     itemHashes: [],
@@ -300,7 +312,7 @@ const D2Sources: {
       1405897559, // Source: "Deep Stone Crypt" raid.
       1692165595, // Source: Rock Bottom.
     ],
-    searchString: '',
+    searchString: [],
   },
   deluxe: {
     itemHashes: [],
@@ -316,14 +328,14 @@ const D2Sources: {
       4069355515, // Source: Handed out at US events in 2019.
       4166998204, // Source: Earned as a pre-order bonus.
     ],
-    searchString: '',
+    searchString: [],
   },
   do: {
     itemHashes: [],
     sourceHashes: [
       146504277, // Source: Earn rank-up packages from Arach Jalaal.
     ],
-    searchString: '',
+    searchString: [],
   },
   dreaming: {
     itemHashes: [
@@ -334,7 +346,7 @@ const D2Sources: {
       2559145507, // Source: Complete activities in the Dreaming City.
       3874934421, // Source: Complete Nightfall strike "The Corrupted."
     ],
-    searchString: '',
+    searchString: [],
   },
   drifter: {
     itemHashes: [
@@ -365,7 +377,7 @@ const D2Sources: {
       3494247523, // Source: Complete the "Season 8: Keepin' On" quest.
       3522070610, // Source: Gambit.
     ],
-    searchString: '',
+    searchString: [],
   },
   dsc: {
     itemHashes: [],
@@ -374,7 +386,7 @@ const D2Sources: {
       1405897559, // Source: "Deep Stone Crypt" raid.
       1692165595, // Source: Rock Bottom.
     ],
-    searchString: '',
+    searchString: [],
   },
   dungeon: {
     itemHashes: [
@@ -390,7 +402,7 @@ const D2Sources: {
       2856954949, // Source: "Let Loose Thy Talons" Exotic quest.
       3597879858, // Source: Presage Exotic Quest
     ],
-    searchString: 'source:pit or source:prophecy or source:presage or source:harbinger',
+    searchString: ['shatteredthrone', 'pit', 'prophecy', 'presage', 'harbinger'],
   },
   edz: {
     itemHashes: [],
@@ -406,7 +418,7 @@ const D2Sources: {
       4214471686, // Source: Adventure "Unsafe at Any Speed" in the European Dead Zone.
       4292996207, // Source: World Quest "Enhance!" in the European Dead Zone.
     ],
-    searchString: '',
+    searchString: [],
   },
   eow: {
     itemHashes: [],
@@ -414,7 +426,7 @@ const D2Sources: {
       2937902448, // Source: Leviathan, Eater of Worlds raid lair.
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
     ],
-    searchString: '',
+    searchString: [],
   },
   ep: {
     itemHashes: [],
@@ -422,7 +434,7 @@ const D2Sources: {
       3353456375, // Defeat 25 Final Bosses
       4137108180, // Source: Escalation Protocol on Mars.
     ],
-    searchString: '',
+    searchString: [],
   },
   europa: {
     itemHashes: [],
@@ -434,7 +446,7 @@ const D2Sources: {
       3125456997, // Source: Europan Tour.
       3965815470, // Source: Rare drop from elected difficulty Empire Hunts.
     ],
-    searchString: '',
+    searchString: [],
   },
   events: {
     itemHashes: [],
@@ -462,8 +474,7 @@ const D2Sources: {
       3952847349, // Source: The Dawning.
       4054646289, // Source: Earned during the seasonal Dawning event.
     ],
-    searchString:
-      'is:dawning or is:crimsondays or is:solstice or is:fotl or is:revelry or is:games',
+    searchString: ['dawning', 'crimsondays', 'solstice', 'fotl', 'revelry', 'games'],
   },
   eververse: {
     itemHashes: [],
@@ -472,21 +483,21 @@ const D2Sources: {
       860688654, // Source: Eververse
       4036739795, // Source: Bright Engrams.
     ],
-    searchString: '',
+    searchString: [],
   },
   exoticcipher: {
     itemHashes: [],
     sourceHashes: [
       4155903822, // Source: Obtained from Master Cryptarch Rahool.
     ],
-    searchString: '',
+    searchString: [],
   },
   fwc: {
     itemHashes: [],
     sourceHashes: [
       3569603185, // Source: Earn rank-up packages from Lakshmi-2.
     ],
-    searchString: '',
+    searchString: [],
   },
   gambit: {
     itemHashes: [
@@ -517,7 +528,7 @@ const D2Sources: {
       3494247523, // Source: Complete the "Season 8: Keepin' On" quest.
       3522070610, // Source: Gambit.
     ],
-    searchString: '',
+    searchString: [],
   },
   gambitprime: {
     itemHashes: [
@@ -531,7 +542,7 @@ const D2Sources: {
     sourceHashes: [
       1952675042, // Source: Complete Gambit Prime matches and increase your rank.
     ],
-    searchString: '',
+    searchString: [],
   },
   garden: {
     itemHashes: [
@@ -540,7 +551,7 @@ const D2Sources: {
     sourceHashes: [
       1491707941, // Source: "Garden of Salvation" raid.
     ],
-    searchString: '',
+    searchString: [],
   },
   gunsmith: {
     itemHashes: [],
@@ -548,21 +559,21 @@ const D2Sources: {
       1788267693, // Source: Earn rank-up packages from Banshee-44.
       2986841134, // Source: Salvager's Salvo Armament Quest
     ],
-    searchString: '',
+    searchString: [],
   },
   harbinger: {
     itemHashes: [],
     sourceHashes: [
       2856954949, // Source: "Let Loose Thy Talons" Exotic quest.
     ],
-    searchString: '',
+    searchString: [],
   },
   ikora: {
     itemHashes: [],
     sourceHashes: [
       3075817319, // Source: Earn rank-up packages from Ikora Rey.
     ],
-    searchString: '',
+    searchString: [],
   },
   io: {
     itemHashes: [],
@@ -574,7 +585,7 @@ const D2Sources: {
       2717017239, // Source: Complete Nightfall strike "The Pyramidion."
       3427537854, // Source: Adventure "Road Rage" on Io.
     ],
-    searchString: '',
+    searchString: [],
   },
   ironbanner: {
     itemHashes: [
@@ -595,7 +606,7 @@ const D2Sources: {
       3072862693, // Source: Complete Iron Banner matches and earn rank-up packages from Lord Saladin.
       3966667255, // Source: Complete Iron Banner's Season 9 Seasonal Pursuit.
     ],
-    searchString: '',
+    searchString: [],
   },
   lastwish: {
     itemHashes: [
@@ -604,14 +615,14 @@ const D2Sources: {
     sourceHashes: [
       2455011338, // Source: Last Wish raid.
     ],
-    searchString: '',
+    searchString: [],
   },
   legendaryengram: {
     itemHashes: [],
     sourceHashes: [
       3334812276, // Source: Open Legendary engrams and earn faction rank-up packages.
     ],
-    searchString: '',
+    searchString: [],
   },
   leviathan: {
     itemHashes: [
@@ -622,7 +633,7 @@ const D2Sources: {
       2765304727, // Source: Leviathan raid on Prestige difficulty.
       4009509410, // Source: Complete challenges in the Leviathan raid.
     ],
-    searchString: '',
+    searchString: [],
   },
   limited: {
     itemHashes: [],
@@ -638,14 +649,14 @@ const D2Sources: {
       4069355515, // Source: Handed out at US events in 2019.
       4166998204, // Source: Earned as a pre-order bonus.
     ],
-    searchString: '',
+    searchString: [],
   },
   lostsectors: {
     itemHashes: [],
     sourceHashes: [
       2203185162, // Source: Solo Legend and Master Lost Sectors
     ],
-    searchString: '',
+    searchString: [],
   },
   mars: {
     itemHashes: [],
@@ -657,7 +668,7 @@ const D2Sources: {
       2926805810, // Source: Complete Nightfall strike "Strange Terrain."
       4137108180, // Source: Escalation Protocol on Mars.
     ],
-    searchString: '',
+    searchString: [],
   },
   menagerie: {
     itemHashes: [
@@ -675,7 +686,7 @@ const D2Sources: {
       2511152325, // Acquired from the Menagerie aboard the Leviathan.
       4130543671, // Acquired from the Menagerie aboard the Leviathan with the requisite combination of runes in the Chalice of Opulence.
     ],
-    searchString: '',
+    searchString: [],
   },
   mercury: {
     itemHashes: [],
@@ -693,7 +704,7 @@ const D2Sources: {
       3964663093, // Source: Rare drop from high-scoring Nightfall strikes on Mercury.
       4263201695, // Source: Complete Nightfall strike "A Garden World."
     ],
-    searchString: '',
+    searchString: [],
   },
   moon: {
     itemHashes: [],
@@ -702,7 +713,7 @@ const D2Sources: {
       1999000205, // Source: Found by exploring the Moon.
       3589340943, // Source: Altars of Sorrow
     ],
-    searchString: '',
+    searchString: [],
   },
   nessus: {
     itemHashes: [],
@@ -718,7 +729,7 @@ const D2Sources: {
       3022766747, // Source: Complete Nightfall strike "The Insight Terminus."
       3067146211, // Source: Complete Nightfall strike "Exodus Crash."
     ],
-    searchString: '',
+    searchString: [],
   },
   nightfall: {
     itemHashes: [],
@@ -745,7 +756,7 @@ const D2Sources: {
       4208190159, // Source: Complete a Nightfall strike.
       4263201695, // Source: Complete Nightfall strike "A Garden World."
     ],
-    searchString: '',
+    searchString: [],
   },
   nightmare: {
     itemHashes: [],
@@ -753,21 +764,21 @@ const D2Sources: {
       550270332, // Source: Complete all Nightmare Hunt time trials on Master difficulty.
       2778435282, // Source: Nightmare Hunts
     ],
-    searchString: '',
+    searchString: [],
   },
   nm: {
     itemHashes: [],
     sourceHashes: [
       1464399708, // Source: Earn rank-up packages from Executor Hideo.
     ],
-    searchString: '',
+    searchString: [],
   },
   pit: {
     itemHashes: [],
     sourceHashes: [
       1745960977, // Source: Pit of Heresy
     ],
-    searchString: '',
+    searchString: [],
   },
   presage: {
     itemHashes: [],
@@ -776,7 +787,7 @@ const D2Sources: {
       2745272818, // Source: Presage Exotic Quest
       3597879858, // Source: Presage Exotic Quest
     ],
-    searchString: '',
+    searchString: [],
   },
   prestige: {
     itemHashes: [],
@@ -785,14 +796,14 @@ const D2Sources: {
       2812190367, // Source: Leviathan, Spire of Stars raid lair on Prestige difficulty.
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
     ],
-    searchString: '',
+    searchString: [],
   },
   prophecy: {
     itemHashes: [],
     sourceHashes: [
       506073192, // Source: Season of Arrivals dungeon.
     ],
-    searchString: '',
+    searchString: [],
   },
   raid: {
     itemHashes: [
@@ -829,8 +840,16 @@ const D2Sources: {
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
       4246883461, // Source: Found in the "Scourge of the Past" raid.
     ],
-    searchString:
-      'source:crownofsorrow or source:deepstonecrypt or source:eow or source:garden or source:lastwish or source:leviathan or source:scourge or source:sos',
+    searchString: [
+      'crownofsorrow',
+      'deepstonecrypt',
+      'eow',
+      'garden',
+      'lastwish',
+      'leviathan',
+      'scourge',
+      'sos',
+    ],
   },
   rasputin: {
     itemHashes: [],
@@ -841,7 +860,7 @@ const D2Sources: {
       3492941398, // Source: Complete quest "The Lie"
       3937492340, // Source: Complete Seraph bounties.
     ],
-    searchString: '',
+    searchString: [],
   },
   saint14: {
     itemHashes: [],
@@ -851,7 +870,7 @@ const D2Sources: {
       4046490681, // Source: Complete the "Global Resonance" Triumph.
       4267157320, // Source: ???????
     ],
-    searchString: '',
+    searchString: [],
   },
   scourge: {
     itemHashes: [
@@ -862,7 +881,7 @@ const D2Sources: {
       2085016678, // Source: Complete the "Scourge of the Past" raid within the first 24 hours after its launch.
       4246883461, // Source: Found in the "Scourge of the Past" raid.
     ],
-    searchString: '',
+    searchString: [],
   },
   seasonpass: {
     itemHashes: [],
@@ -871,7 +890,7 @@ const D2Sources: {
       1838401392, // Source: Earned as a Season Pass reward.
       2379344669, // Source: Season Pass.
     ],
-    searchString: '',
+    searchString: [],
   },
   shatteredthrone: {
     itemHashes: [
@@ -880,7 +899,7 @@ const D2Sources: {
       2844014413, // Pallas Galliot
     ],
     sourceHashes: [],
-    searchString: '',
+    searchString: [],
   },
   shaxx: {
     itemHashes: [
@@ -915,14 +934,14 @@ const D2Sources: {
       2915991372, // Source: Crucible
       3656787928, // Source: Crucible Salvager's Salvo Armament
     ],
-    searchString: '',
+    searchString: [],
   },
   shipwright: {
     itemHashes: [],
     sourceHashes: [
       96303009, // Source: Purchased from Amanda Holliday.
     ],
-    searchString: '',
+    searchString: [],
   },
   sos: {
     itemHashes: [],
@@ -930,7 +949,7 @@ const D2Sources: {
       1675483099, // Source: Leviathan, Spire of Stars raid lair.
       2812190367, // Source: Leviathan, Spire of Stars raid lair on Prestige difficulty.
     ],
-    searchString: '',
+    searchString: [],
   },
   strikes: {
     itemHashes: [
@@ -959,7 +978,7 @@ const D2Sources: {
       2335095658, // Source: Strikes.
       2527168932, // Source: Complete strikes and earn rank-up packages from Commander Zavala.
     ],
-    searchString: '',
+    searchString: [],
   },
   sundial: {
     itemHashes: [],
@@ -967,7 +986,7 @@ const D2Sources: {
       1618754228, // Source: Acquired from the Sundial activity on Mercury.
       2627087475, // Source: Complete obelisk bounties and increase the Resonance Rank of obelisks across the system.
     ],
-    searchString: '',
+    searchString: [],
   },
   tangled: {
     itemHashes: [
@@ -982,7 +1001,7 @@ const D2Sources: {
       2805208672, // Source: Complete Nightfall strike "The Hollowed Lair."
       4140654910, // Source: Eliminate all Barons on the Tangled Shore.
     ],
-    searchString: '',
+    searchString: [],
   },
   titan: {
     itemHashes: [],
@@ -993,7 +1012,7 @@ const D2Sources: {
       636474187, // Source: Adventure "Deathless" on Saturn's Moon, Titan.
       3534706087, // Source: Complete activities and earn rank-up packages on Saturn's Moon, Titan.
     ],
-    searchString: '',
+    searchString: [],
   },
   trials: {
     itemHashes: [
@@ -1010,7 +1029,7 @@ const D2Sources: {
       3471208558, // Source: Win matches in the Trials of Osiris.
       3543690049, // Source: Complete a flawless Trials ticket.
     ],
-    searchString: '',
+    searchString: [],
   },
   umbral: {
     itemHashes: [],
@@ -1018,7 +1037,7 @@ const D2Sources: {
       287889699, // Source: Umbral Engram Tutorial
       1286883820, // Source: Prismatic Recaster
     ],
-    searchString: '',
+    searchString: [],
   },
   vexoffensive: {
     itemHashes: [
@@ -1071,7 +1090,7 @@ const D2Sources: {
     sourceHashes: [
       4122810030, // Source: Complete seasonal activities during Season of the Undying.
     ],
-    searchString: '',
+    searchString: [],
   },
   wartable: {
     itemHashes: [],
@@ -1079,7 +1098,7 @@ const D2Sources: {
       2653840925, // Source: Challenger's Proving VII Quest
       4079816474, // Source: War Table
     ],
-    searchString: '',
+    searchString: [],
   },
   wrathborn: {
     itemHashes: [
@@ -1105,7 +1124,7 @@ const D2Sources: {
       841568343, // Source: "Hunt for the Wrathborn" quest.
       3107094548, // Source: Coup de Grâce
     ],
-    searchString: '',
+    searchString: [],
   },
   zavala: {
     itemHashes: [
@@ -1134,7 +1153,7 @@ const D2Sources: {
       2335095658, // Source: Strikes.
       2527168932, // Source: Complete strikes and earn rank-up packages from Commander Zavala.
     ],
-    searchString: '',
+    searchString: [],
   },
 };
 

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -1,4 +1,6 @@
-const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[] } } = {
+const D2Sources: {
+  [key: string]: { itemHashes: number[]; sourceHashes: number[]; searchString: string };
+} = {
   adventure: {
     itemHashes: [],
     sourceHashes: [
@@ -23,12 +25,14 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3754173885, // Source: Adventure "Getting Your Hands Dirty" in the European Dead Zone.
       4214471686, // Source: Adventure "Unsafe at Any Speed" in the European Dead Zone.
     ],
+    searchString: '',
   },
   battlegrounds: {
     itemHashes: [],
     sourceHashes: [
       3391325445, // Source: Battlegrounds
     ],
+    searchString: '',
   },
   blackarmory: {
     itemHashes: [
@@ -64,6 +68,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4247521481, // Source: Complete the "Beautiful but Deadly" Triumph.
       4290227252, // Source: Complete a Volundr Forge ignition.
     ],
+    searchString: '',
   },
   calus: {
     itemHashes: [
@@ -84,6 +89,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4009509410, // Source: Complete challenges in the Leviathan raid.
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
     ],
+    searchString: '',
   },
   campaign: {
     itemHashes: [],
@@ -119,24 +125,28 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4288102251, // Requires 1,000 Titan Kills
       4290499613, // Source: Complete the campaign as a Hunter.
     ],
+    searchString: '',
   },
   cayde6: {
     itemHashes: [],
     sourceHashes: [
       2206233229, // Source: Follow treasure maps.
     ],
+    searchString: '',
   },
   cipher: {
     itemHashes: [],
     sourceHashes: [
       4155903822, // Source: Obtained from Master Cryptarch Rahool.
     ],
+    searchString: '',
   },
   contact: {
     itemHashes: [],
     sourceHashes: [
       2039343154, // Source: Contact public event.
     ],
+    searchString: '',
   },
   crownofsorrow: {
     itemHashes: [
@@ -149,6 +159,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2399751101, // Acquired from the raid "Crown of Sorrow."
       3147603678, // Acquired from the raid "Crown of Sorrow."
     ],
+    searchString: '',
   },
   crucible: {
     itemHashes: [
@@ -183,6 +194,104 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2915991372, // Source: Crucible
       3656787928, // Source: Crucible Salvager's Salvo Armament
     ],
+    searchString: '',
+  },
+  dcv: {
+    itemHashes: [
+      417164956, // Jötunn
+      947448544, // Shadow of Earth Shell
+      1661191192, // The Tribute Hall
+      1661191193, // Crown of Sorrow
+      1661191194, // A Hall of Delights
+      1661191195, // The Imperial Menagerie
+      2027598066, // Imperial Opulence
+      2027598067, // Imperial Dress
+      2557722678, // Midnight Smith
+      2816212794, // Bad Juju
+      3176509806, // Árma Mákhēs
+      3211806999, // Izanagi's Burden
+      3580904580, // Legend of Acrius
+      3588934839, // Le Monarque
+      3650581584, // New Age Black Armory
+      3650581585, // Refurbished Black Armory
+      3650581586, // Rasmussen Clan
+      3650581587, // House of Meyrin
+      3650581588, // Satou Tribe
+      3650581589, // Bergusian Night
+      3841416152, // Golden Empire
+      3841416153, // Goldleaf
+      3841416154, // Shadow Gilt
+      3841416155, // Cinderchar
+      3875444086, // The Emperor's Chosen
+    ],
+    sourceHashes: [
+      75031309, // Source: Found in forge ignitions.
+      80684972, // Source: Complete a Heroic Adventure on Mercury.
+      148542898, // Source: Equip the full Mercury destination set on a Warlock.
+      194661944, // Source: Adventure "Siren Song" on Saturn's moon, Titan.
+      266896577, // Source: Solve the Norse glyph puzzle.
+      315474873, // Source: Complete activities and earn rank-up packages on Io.
+      354493557, // Source: Complete Nightfall strike "Savathûn's Song."
+      439994003, // Source: Complete the "Master Smith" Triumph.
+      482012099, // Source: Adventure "Thief of Thieves" on Saturn's Moon, Titan.
+      636474187, // Source: Adventure "Deathless" on Saturn's Moon, Titan.
+      705895461, // Acquired from the Menagerie.
+      925197669, // Source: Complete a Bergusia Forge ignition.
+      948753311, // Source: Found by completing Volundr Forge ignitions.
+      1036506031, // Source: Complete activities and earn rank-up packages on Mars.
+      1067250718, // Source: Adventure "Arecibo" on Io.
+      1175566043, // Source: Complete Nightfall strike "A Garden World."
+      1286332045, // Source: Found by completing Izanami Forge ignitions.
+      1299614150, // Source: [REDACTED] on Mars.
+      1400219831, // Source: Equip the full Mercury destination set on a Hunter.
+      1411886787, // Source: Equip the full Mercury destination set on a Titan.
+      1457456824, // Source: Complete the "Reunited Siblings" Triumph.
+      1465990789, // Source: Solve the Japanese glyph puzzle.
+      1483048674, // Source: Complete the "Scourge of the Past" raid.
+      1581680964, // Source: Complete Nightfall strike "Tree of Probabilities."
+      1596507419, // Source: Complete a Gofannon Forge ignition.
+      1618754228, // Source: Acquired from the Sundial activity on Mercury.
+      1654120320, // Source: Complete activities and earn rank-up packages on Mercury.
+      1675483099, // Source: Leviathan, Spire of Stars raid lair.
+      1832642406, // Source: World Quest "Dynasty" on Io.
+      1924238751, // Source: Complete Nightfall strike "Will of the Thousands."
+      2062058385, // Source: Crafted in a Black Armory forge.
+      2085016678, // Source: Complete the "Scourge of the Past" raid within the first 24 hours after its launch.
+      2310754348, // Source: World Quest "Data Recovery" on Mars.
+      2384327872, // Source: Solve the French glyph puzzle.
+      2392127416, // Source: Adventure "Cliffhanger" on Io.
+      2399751101, // Acquired from the raid "Crown of Sorrow."
+      2487203690, // Source: Complete Nightfall strike "Tree of Probabilities."
+      2511152325, // Acquired from the Menagerie aboard the Leviathan.
+      2541753910, // Source: Complete the "Master Blaster" Triumph.
+      2653618435, // Source: Leviathan raid.
+      2717017239, // Source: Complete Nightfall strike "The Pyramidion."
+      2765304727, // Source: Leviathan raid on Prestige difficulty.
+      2812190367, // Source: Leviathan, Spire of Stars raid lair on Prestige difficulty.
+      2926805810, // Source: Complete Nightfall strike "Strange Terrain."
+      2937902448, // Source: Leviathan, Eater of Worlds raid lair.
+      2966694626, // Source: Found by solving the mysteries behind the Black Armory's founding families.
+      3047033583, // Source: Returned the Obsidian Accelerator.
+      3079246067, // Source: Complete Osiris' Lost Prophecies for Brother Vance on Mercury.
+      3147603678, // Acquired from the raid "Crown of Sorrow."
+      3257722699, // Source: Complete the "Clean Up on Aisle Five" Triumph.
+      3353456375, // Defeat 25 Final Bosses
+      3390164851, // Source: Found by turning in Black Armory bounties.
+      3427537854, // Source: Adventure "Road Rage" on Io.
+      3534706087, // Source: Complete activities and earn rank-up packages on Saturn's Moon, Titan.
+      3764925750, // Source: Complete an Izanami Forge ignition.
+      3964663093, // Source: Rare drop from high-scoring Nightfall strikes on Mercury.
+      4009509410, // Source: Complete challenges in the Leviathan raid.
+      4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
+      4101102010, // Source: Found by completing Bergusia Forge ignitions.
+      4137108180, // Source: Escalation Protocol on Mars.
+      4246883461, // Source: Found in the "Scourge of the Past" raid.
+      4247521481, // Source: Complete the "Beautiful but Deadly" Triumph.
+      4263201695, // Source: Complete Nightfall strike "A Garden World."
+      4290227252, // Source: Complete a Volundr Forge ignition.
+    ],
+    searchString:
+      'source:mercury or source:mars or source:titan or source:io or source:leviathan or source:ep or source:blackarmory or source:menagerie or source:eow or source:sos or source:scourge or source:crownofsorrow',
   },
   deepstonecrypt: {
     itemHashes: [],
@@ -191,6 +300,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1405897559, // Source: "Deep Stone Crypt" raid.
       1692165595, // Source: Rock Bottom.
     ],
+    searchString: '',
   },
   deluxe: {
     itemHashes: [],
@@ -206,12 +316,14 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4069355515, // Source: Handed out at US events in 2019.
       4166998204, // Source: Earned as a pre-order bonus.
     ],
+    searchString: '',
   },
   do: {
     itemHashes: [],
     sourceHashes: [
       146504277, // Source: Earn rank-up packages from Arach Jalaal.
     ],
+    searchString: '',
   },
   dreaming: {
     itemHashes: [
@@ -222,6 +334,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2559145507, // Source: Complete activities in the Dreaming City.
       3874934421, // Source: Complete Nightfall strike "The Corrupted."
     ],
+    searchString: '',
   },
   drifter: {
     itemHashes: [
@@ -252,6 +365,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3494247523, // Source: Complete the "Season 8: Keepin' On" quest.
       3522070610, // Source: Gambit.
     ],
+    searchString: '',
   },
   dsc: {
     itemHashes: [],
@@ -260,6 +374,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1405897559, // Source: "Deep Stone Crypt" raid.
       1692165595, // Source: Rock Bottom.
     ],
+    searchString: '',
   },
   dungeon: {
     itemHashes: [
@@ -275,6 +390,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2856954949, // Source: "Let Loose Thy Talons" Exotic quest.
       3597879858, // Source: Presage Exotic Quest
     ],
+    searchString: 'source:pit or source:prophecy or source:presage or source:harbinger',
   },
   edz: {
     itemHashes: [],
@@ -290,6 +406,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4214471686, // Source: Adventure "Unsafe at Any Speed" in the European Dead Zone.
       4292996207, // Source: World Quest "Enhance!" in the European Dead Zone.
     ],
+    searchString: '',
   },
   eow: {
     itemHashes: [],
@@ -297,6 +414,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2937902448, // Source: Leviathan, Eater of Worlds raid lair.
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
     ],
+    searchString: '',
   },
   ep: {
     itemHashes: [],
@@ -304,6 +422,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3353456375, // Defeat 25 Final Bosses
       4137108180, // Source: Escalation Protocol on Mars.
     ],
+    searchString: '',
   },
   europa: {
     itemHashes: [],
@@ -315,6 +434,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3125456997, // Source: Europan Tour.
       3965815470, // Source: Rare drop from elected difficulty Empire Hunts.
     ],
+    searchString: '',
   },
   events: {
     itemHashes: [],
@@ -342,6 +462,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3952847349, // Source: The Dawning.
       4054646289, // Source: Earned during the seasonal Dawning event.
     ],
+    searchString:
+      'is:dawning or is:crimsondays or is:solstice or is:fotl or is:revelry or is:games',
   },
   eververse: {
     itemHashes: [],
@@ -350,18 +472,21 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       860688654, // Source: Eververse
       4036739795, // Source: Bright Engrams.
     ],
+    searchString: '',
   },
   exoticcipher: {
     itemHashes: [],
     sourceHashes: [
       4155903822, // Source: Obtained from Master Cryptarch Rahool.
     ],
+    searchString: '',
   },
   fwc: {
     itemHashes: [],
     sourceHashes: [
       3569603185, // Source: Earn rank-up packages from Lakshmi-2.
     ],
+    searchString: '',
   },
   gambit: {
     itemHashes: [
@@ -392,6 +517,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3494247523, // Source: Complete the "Season 8: Keepin' On" quest.
       3522070610, // Source: Gambit.
     ],
+    searchString: '',
   },
   gambitprime: {
     itemHashes: [
@@ -405,6 +531,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
     sourceHashes: [
       1952675042, // Source: Complete Gambit Prime matches and increase your rank.
     ],
+    searchString: '',
   },
   garden: {
     itemHashes: [
@@ -413,6 +540,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
     sourceHashes: [
       1491707941, // Source: "Garden of Salvation" raid.
     ],
+    searchString: '',
   },
   gunsmith: {
     itemHashes: [],
@@ -420,18 +548,21 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1788267693, // Source: Earn rank-up packages from Banshee-44.
       2986841134, // Source: Salvager's Salvo Armament Quest
     ],
+    searchString: '',
   },
   harbinger: {
     itemHashes: [],
     sourceHashes: [
       2856954949, // Source: "Let Loose Thy Talons" Exotic quest.
     ],
+    searchString: '',
   },
   ikora: {
     itemHashes: [],
     sourceHashes: [
       3075817319, // Source: Earn rank-up packages from Ikora Rey.
     ],
+    searchString: '',
   },
   io: {
     itemHashes: [],
@@ -443,6 +574,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2717017239, // Source: Complete Nightfall strike "The Pyramidion."
       3427537854, // Source: Adventure "Road Rage" on Io.
     ],
+    searchString: '',
   },
   ironbanner: {
     itemHashes: [
@@ -463,6 +595,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3072862693, // Source: Complete Iron Banner matches and earn rank-up packages from Lord Saladin.
       3966667255, // Source: Complete Iron Banner's Season 9 Seasonal Pursuit.
     ],
+    searchString: '',
   },
   lastwish: {
     itemHashes: [
@@ -471,12 +604,14 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
     sourceHashes: [
       2455011338, // Source: Last Wish raid.
     ],
+    searchString: '',
   },
   legendaryengram: {
     itemHashes: [],
     sourceHashes: [
       3334812276, // Source: Open Legendary engrams and earn faction rank-up packages.
     ],
+    searchString: '',
   },
   leviathan: {
     itemHashes: [
@@ -487,6 +622,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2765304727, // Source: Leviathan raid on Prestige difficulty.
       4009509410, // Source: Complete challenges in the Leviathan raid.
     ],
+    searchString: '',
   },
   limited: {
     itemHashes: [],
@@ -502,12 +638,14 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4069355515, // Source: Handed out at US events in 2019.
       4166998204, // Source: Earned as a pre-order bonus.
     ],
+    searchString: '',
   },
   lostsectors: {
     itemHashes: [],
     sourceHashes: [
       2203185162, // Source: Solo Legend and Master Lost Sectors
     ],
+    searchString: '',
   },
   mars: {
     itemHashes: [],
@@ -519,6 +657,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2926805810, // Source: Complete Nightfall strike "Strange Terrain."
       4137108180, // Source: Escalation Protocol on Mars.
     ],
+    searchString: '',
   },
   menagerie: {
     itemHashes: [
@@ -536,6 +675,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2511152325, // Acquired from the Menagerie aboard the Leviathan.
       4130543671, // Acquired from the Menagerie aboard the Leviathan with the requisite combination of runes in the Chalice of Opulence.
     ],
+    searchString: '',
   },
   mercury: {
     itemHashes: [],
@@ -553,6 +693,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3964663093, // Source: Rare drop from high-scoring Nightfall strikes on Mercury.
       4263201695, // Source: Complete Nightfall strike "A Garden World."
     ],
+    searchString: '',
   },
   moon: {
     itemHashes: [],
@@ -561,6 +702,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1999000205, // Source: Found by exploring the Moon.
       3589340943, // Source: Altars of Sorrow
     ],
+    searchString: '',
   },
   nessus: {
     itemHashes: [],
@@ -576,6 +718,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3022766747, // Source: Complete Nightfall strike "The Insight Terminus."
       3067146211, // Source: Complete Nightfall strike "Exodus Crash."
     ],
+    searchString: '',
   },
   nightfall: {
     itemHashes: [],
@@ -602,6 +745,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4208190159, // Source: Complete a Nightfall strike.
       4263201695, // Source: Complete Nightfall strike "A Garden World."
     ],
+    searchString: '',
   },
   nightmare: {
     itemHashes: [],
@@ -609,12 +753,21 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       550270332, // Source: Complete all Nightmare Hunt time trials on Master difficulty.
       2778435282, // Source: Nightmare Hunts
     ],
+    searchString: '',
   },
   nm: {
     itemHashes: [],
     sourceHashes: [
       1464399708, // Source: Earn rank-up packages from Executor Hideo.
     ],
+    searchString: '',
+  },
+  pit: {
+    itemHashes: [],
+    sourceHashes: [
+      1745960977, // Source: Pit of Heresy
+    ],
+    searchString: '',
   },
   presage: {
     itemHashes: [],
@@ -623,6 +776,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2745272818, // Source: Presage Exotic Quest
       3597879858, // Source: Presage Exotic Quest
     ],
+    searchString: '',
   },
   prestige: {
     itemHashes: [],
@@ -631,12 +785,14 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2812190367, // Source: Leviathan, Spire of Stars raid lair on Prestige difficulty.
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
     ],
+    searchString: '',
   },
   prophecy: {
     itemHashes: [],
     sourceHashes: [
       506073192, // Source: Season of Arrivals dungeon.
     ],
+    searchString: '',
   },
   raid: {
     itemHashes: [
@@ -646,6 +802,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2557722678, // Midnight Smith
       3580904580, // Legend of Acrius
       3668669364, // Dreaming Spectrum
+      4103414242, // Divinity
     ],
     sourceHashes: [
       158391786, // Guide 10 encounters
@@ -672,6 +829,8 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
       4246883461, // Source: Found in the "Scourge of the Past" raid.
     ],
+    searchString:
+      'source:crownofsorrow or source:deepstonecrypt or source:eow or source:garden or source:lastwish or source:leviathan or source:scourge or source:sos',
   },
   rasputin: {
     itemHashes: [],
@@ -682,6 +841,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3492941398, // Source: Complete quest "The Lie"
       3937492340, // Source: Complete Seraph bounties.
     ],
+    searchString: '',
   },
   saint14: {
     itemHashes: [],
@@ -691,6 +851,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       4046490681, // Source: Complete the "Global Resonance" Triumph.
       4267157320, // Source: ???????
     ],
+    searchString: '',
   },
   scourge: {
     itemHashes: [
@@ -701,6 +862,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2085016678, // Source: Complete the "Scourge of the Past" raid within the first 24 hours after its launch.
       4246883461, // Source: Found in the "Scourge of the Past" raid.
     ],
+    searchString: '',
   },
   seasonpass: {
     itemHashes: [],
@@ -709,6 +871,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1838401392, // Source: Earned as a Season Pass reward.
       2379344669, // Source: Season Pass.
     ],
+    searchString: '',
   },
   shatteredthrone: {
     itemHashes: [
@@ -717,6 +880,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2844014413, // Pallas Galliot
     ],
     sourceHashes: [],
+    searchString: '',
   },
   shaxx: {
     itemHashes: [
@@ -751,12 +915,14 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2915991372, // Source: Crucible
       3656787928, // Source: Crucible Salvager's Salvo Armament
     ],
+    searchString: '',
   },
   shipwright: {
     itemHashes: [],
     sourceHashes: [
       96303009, // Source: Purchased from Amanda Holliday.
     ],
+    searchString: '',
   },
   sos: {
     itemHashes: [],
@@ -764,6 +930,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1675483099, // Source: Leviathan, Spire of Stars raid lair.
       2812190367, // Source: Leviathan, Spire of Stars raid lair on Prestige difficulty.
     ],
+    searchString: '',
   },
   strikes: {
     itemHashes: [
@@ -792,6 +959,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2335095658, // Source: Strikes.
       2527168932, // Source: Complete strikes and earn rank-up packages from Commander Zavala.
     ],
+    searchString: '',
   },
   sundial: {
     itemHashes: [],
@@ -799,6 +967,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       1618754228, // Source: Acquired from the Sundial activity on Mercury.
       2627087475, // Source: Complete obelisk bounties and increase the Resonance Rank of obelisks across the system.
     ],
+    searchString: '',
   },
   tangled: {
     itemHashes: [
@@ -813,6 +982,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2805208672, // Source: Complete Nightfall strike "The Hollowed Lair."
       4140654910, // Source: Eliminate all Barons on the Tangled Shore.
     ],
+    searchString: '',
   },
   titan: {
     itemHashes: [],
@@ -823,6 +993,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       636474187, // Source: Adventure "Deathless" on Saturn's Moon, Titan.
       3534706087, // Source: Complete activities and earn rank-up packages on Saturn's Moon, Titan.
     ],
+    searchString: '',
   },
   trials: {
     itemHashes: [
@@ -839,6 +1010,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       3471208558, // Source: Win matches in the Trials of Osiris.
       3543690049, // Source: Complete a flawless Trials ticket.
     ],
+    searchString: '',
   },
   umbral: {
     itemHashes: [],
@@ -846,6 +1018,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       287889699, // Source: Umbral Engram Tutorial
       1286883820, // Source: Prismatic Recaster
     ],
+    searchString: '',
   },
   vexoffensive: {
     itemHashes: [
@@ -898,6 +1071,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
     sourceHashes: [
       4122810030, // Source: Complete seasonal activities during Season of the Undying.
     ],
+    searchString: '',
   },
   wartable: {
     itemHashes: [],
@@ -905,6 +1079,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2653840925, // Source: Challenger's Proving VII Quest
       4079816474, // Source: War Table
     ],
+    searchString: '',
   },
   wrathborn: {
     itemHashes: [
@@ -930,6 +1105,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       841568343, // Source: "Hunt for the Wrathborn" quest.
       3107094548, // Source: Coup de Grâce
     ],
+    searchString: '',
   },
   zavala: {
     itemHashes: [
@@ -958,6 +1134,7 @@ const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]
       2335095658, // Source: Strikes.
       2527168932, // Source: Complete strikes and earn rank-up packages from Commander Zavala.
     ],
+    searchString: '',
   },
 };
 

--- a/src/generate-source-info.ts
+++ b/src/generate-source-info.ts
@@ -29,6 +29,7 @@ interface Categories {
        * and include their children in this source
        */
       presentationNodes?: (string | number)[];
+      searchString?: string;
     }
   >;
   /** i don't really remember why this exists */
@@ -72,6 +73,7 @@ const D2Sources: Record<
   {
     itemHashes: number[];
     sourceHashes: number[];
+    searchString: string;
   }
 > = {};
 
@@ -92,6 +94,10 @@ for (const [sourceTag, matchRule] of Object.entries(categories.sources)) {
   // string match this category's source descriptions
   const sourceHashes = applySourceStringRules(sourcesInfo, matchRule);
   assignedSources.push(...sourceHashes);
+  let searchString = '';
+  if (matchRule.searchString) {
+    searchString = matchRule.searchString;
+  }
 
   // worth noting if one of our rules has become defunct
   if (!sourceHashes.length) {
@@ -142,6 +148,7 @@ for (const [sourceTag, matchRule] of Object.entries(categories.sources)) {
   D2Sources[sourceTag] = {
     itemHashes,
     sourceHashes,
+    searchString,
   };
 
   // lastly add aliases and copy info
@@ -160,7 +167,7 @@ const D2SourcesStringified = stringifyObject(D2SourcesSorted, {
   indent: '  ',
 });
 
-const pretty = `const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[] } } = ${D2SourcesStringified};\n\nexport default D2Sources;`;
+const pretty = `const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]; searchString: string } } = ${D2SourcesStringified};\n\nexport default D2Sources;`;
 
 // annotate the file with sources or item names next to matching hashes
 const annotated = annotate(pretty, sourcesInfo);

--- a/src/generate-source-info.ts
+++ b/src/generate-source-info.ts
@@ -29,7 +29,7 @@ interface Categories {
        * and include their children in this source
        */
       presentationNodes?: (string | number)[];
-      searchString?: string;
+      searchString?: string[];
     }
   >;
   /** i don't really remember why this exists */
@@ -73,7 +73,7 @@ const D2Sources: Record<
   {
     itemHashes: number[];
     sourceHashes: number[];
-    searchString: string;
+    searchString: string[];
   }
 > = {};
 
@@ -94,9 +94,9 @@ for (const [sourceTag, matchRule] of Object.entries(categories.sources)) {
   // string match this category's source descriptions
   const sourceHashes = applySourceStringRules(sourcesInfo, matchRule);
   assignedSources.push(...sourceHashes);
-  let searchString = '';
+  let searchString: string[] = [];
   if (matchRule.searchString) {
-    searchString = matchRule.searchString;
+    searchString = [...matchRule.searchString];
   }
 
   // worth noting if one of our rules has become defunct
@@ -167,7 +167,7 @@ const D2SourcesStringified = stringifyObject(D2SourcesSorted, {
   indent: '  ',
 });
 
-const pretty = `const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]; searchString: string } } = ${D2SourcesStringified};\n\nexport default D2Sources;`;
+const pretty = `const D2Sources: { [key: string]: { itemHashes: number[]; sourceHashes: number[]; searchString: string[] } } = ${D2SourcesStringified};\n\nexport default D2Sources;`;
 
 // annotate the file with sources or item names next to matching hashes
 const annotated = annotate(pretty, sourcesInfo);


### PR DESCRIPTION
…urce-info.ts

#255 

this gives d2ai the ability to tell DIM that 
`source:events`  is equal to `is:dawning or is:crimsondays or is:solstice or is:fotl or is:revelry or is:games`

`source:raid` is equal to `source:crownofsorrow or source:deepstonecrypt or source:eow or source:garden or source:lastwish or source:leviathan or source:scourge or source:sos`

`source:dcv` is equal to `source:mercury or source:mars or source:titan or source:io or source:leviathan or source:ep or source:blackarmory or source:menagerie or source:eow or source:sos or source:scourge or source:crownofsorrow`

`source:dungeon` is equal to `source:pit or source:prophecy or source:presage or source:harbinger`

EDIT: Once `searchString` is implemented in DIM we can remove the `includes` and `excludes` from the associated `tag` thereby reducing the file size of `missing-source-info.ts` and making these much easier to maintain.