### PR TITLE
Generate hashes of Resonant Elements

### DIFF
--- a/output/crafting-resonant-elements.ts
+++ b/output/crafting-resonant-elements.ts
@@ -1,0 +1,6 @@
+export const resonantElementTagsByObjectiveHash: Record<number, string> = {
+  2215515944: 'ruinous', // Ruinous Element
+  2215515945: 'adroit', // Adroit Element
+  2215515946: 'mutable', // Mutable Element
+  2215515947: 'energetic', // Energetic Element
+} as const;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "generate:season-info-ts": "fse copy --quiet data/seasons/d2-season-info.ts output/d2-season-info.ts",
     "generate:trials-objectives": "dotenv node built/src/generate-trials-objectives.js",
     "generate:crafting-enhanced-intrinsics": "dotenv node built/src/generate-crafting-enhanced-intrinsics.js",
+    "generate:crafting-resonant-elements": "dotenv node built/src/generate-crafting-resonant-elements.js",
     "generate-data": "run-s build generate:*"
   },
   "husky": {

--- a/src/generate-crafting-resonant-elements.ts
+++ b/src/generate-crafting-resonant-elements.ts
@@ -1,0 +1,45 @@
+/**
+ * Collect extractable Resonant Elements so that we can filter Deepsight
+ * weapons by the materials that can be extracted from them.
+ */
+import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { PlugCategoryHashes } from '../data/generated-enums.js';
+import { writeFile } from './helpers.js';
+
+loadLocal();
+
+const allResonantElements: {
+  objectiveHash: number;
+  tag: string;
+  name: string;
+}[] = [];
+
+const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const resonanceExtractionPlugs = inventoryItems.filter(
+  (i) =>
+    i.plug?.plugCategoryHash === PlugCategoryHashes.CraftingPlugsWeaponsModsExtractors &&
+    i.displayProperties.name
+);
+for (const plug of resonanceExtractionPlugs) {
+  const objectiveDef = get('DestinyObjectiveDefinition', plug.hash);
+  if (objectiveDef) {
+    // Ruinous Element -> ruinous
+    const tag = objectiveDef.progressDescription
+      .toLowerCase()
+      .replace(' ', '')
+      .replace(/element$/, '');
+    if (tag) {
+      allResonantElements.push({
+        objectiveHash: objectiveDef.hash,
+        tag,
+        name: objectiveDef.progressDescription,
+      });
+    }
+  }
+}
+
+const outString = `
+export const resonantElementTagsByObjectiveHash: Record<number, string> = {
+${allResonantElements.map((e) => `  ${e.objectiveHash}: '${e.tag}', // ${e.name}`).join('\n')}
+} as const;`;
+writeFile('./output/crafting-resonant-elements.ts', outString);


### PR DESCRIPTION
This PR generates a mapping of Resonant Element objective hashes to a 'tag' that we can use in a search query.

See: https://github.com/DestinyItemManager/DIM/pull/8026