### PR TITLE
Look up Resonant Element objectives by name instead of assuming their hash matches the plug

### DIFF
--- a/output/crafting-resonant-elements.ts
+++ b/output/crafting-resonant-elements.ts
@@ -3,4 +3,5 @@ export const resonantElementTagsByObjectiveHash: Record<number, string> = {
   2215515945: 'adroit', // Adroit Element
   2215515946: 'mutable', // Mutable Element
   2215515947: 'energetic', // Energetic Element
+  3934906303: 'drowned', // Drowned Element
 } as const;


### PR DESCRIPTION
This fixes an issue whereby Deepsight weapons with raid perks do not show that Drowned Elements can be extracted from them. Once DIM picks this change up, the `deepsight:drowned` search filter will become available.

I was previously assuming that the hashes of Resonant Element plugs (which show up in the Deepsight Resonance socket on weapons) would match the corresponding objective hashes (which show up on weapon perks). This is true for most Resonant Elements, but isn't the case for Drowned Elements which are used for raid-exclusive perks.