### PR TITLE
Source ritual / pinnacle

### DIFF
--- a/data/sources/categories.json
+++ b/data/sources/categories.json
@@ -520,6 +520,42 @@
       "includes": ["King's Fall"],
       "alias": ["kf"]
     },
+    "weapon:ritual": {
+      "includes": [
+        "Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.",
+        "Source: Earn ranks in Vanguard strikes, Crucible, or Gambit."
+      ],
+      "items": [
+        "Komodo-4FR",
+        "Buzzard",
+        "Edgewise",
+        "Exit Strategy",
+        "Python",
+        "Randy's Throwing Knife",
+        "Point of the Stag",
+        "Adored",
+        "Null Composure",
+        "Felwinter's Lie"
+      ]
+    },
+    "weapon:pinnacle": {
+      "includes": [
+        "Source: Reach a Glory Rank of \"Fabled\" in the Crucible.",
+        "Source: Reach Glory Rank \"Legend\" in the Crucible.",
+        "Source: Complete the \"Breakneck\" quest from the Drifter.",
+        "Source: Complete the \"Clean Getaway\" quest.",
+        "Source: Complete the \"Loaded Question\" quest from Zavala.",
+        "Source: Complete the \"A Loud Racket\" quest."
+      ],
+      "items": [
+        "Oxygen SR3",
+        "21% Delirium",
+        "The Recluse",
+        "Hush",
+        "Revoker",
+        "578459533"
+      ]
+    },
     "ignore": {
       "includes": [
         "Forging Your Own Path",

--- a/data/sources/categories.json
+++ b/data/sources/categories.json
@@ -520,7 +520,7 @@
       "includes": ["King's Fall"],
       "alias": ["kf"]
     },
-    "weapon:ritual": {
+    "ritual-weapon": {
       "includes": [
         "Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.",
         "Source: Earn ranks in Vanguard strikes, Crucible, or Gambit."
@@ -538,7 +538,7 @@
         "Felwinter's Lie"
       ]
     },
-    "weapon:pinnacle": {
+    "pinnacle-weapon": {
       "includes": [
         "Source: Reach a Glory Rank of \"Fabled\" in the Crucible.",
         "Source: Reach Glory Rank \"Legend\" in the Crucible.",

--- a/output/missing-source-info.ts
+++ b/output/missing-source-info.ts
@@ -2992,6 +2992,8 @@ const missingSources: { [key: string]: number[] } = {
     4177293424, // TM-Cogburn Custom Cover
     4288623897, // TM-Earp Custom Vest
   ],
+  'weapon:pinnacle': [],
+  'weapon:ritual': [],
   wellspring: [],
   wrathborn: [],
   zavala: [

--- a/output/missing-source-info.ts
+++ b/output/missing-source-info.ts
@@ -2308,6 +2308,7 @@ const missingSources: { [key: string]: number[] } = {
     3323316553, // Sovereign Vest
     4083497488, // Sovereign Gloves
   ],
+  'pinnacle-weapon': [],
   pit: [],
   plunder: [],
   presage: [],
@@ -2542,6 +2543,7 @@ const missingSources: { [key: string]: number[] } = {
     4251770245, // Boots of the Emperor's Agent
   ],
   rasputin: [],
+  'ritual-weapon': [],
   saint14: [],
   scourge: [
     350056552, // Bladesmith's Memory Mask
@@ -2992,8 +2994,6 @@ const missingSources: { [key: string]: number[] } = {
     4177293424, // TM-Cogburn Custom Cover
     4288623897, // TM-Earp Custom Vest
   ],
-  'weapon:pinnacle': [],
-  'weapon:ritual': [],
   wellspring: [],
   wrathborn: [],
   zavala: [

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -1471,6 +1471,44 @@ const D2Sources: {
     ],
     searchString: [],
   },
+  'weapon:pinnacle': {
+    itemHashes: [
+      578459533, // Wendigo GL3
+      654608616, // Revoker
+      1584643826, // Hush
+      1600633250, // 21% Delirium
+      3354242550, // The Recluse
+      3907337522, // Oxygen SR3
+    ],
+    sourceHashes: [
+      598662729, // Source: Reach Glory Rank "Legend" in the Crucible.
+      1162859311, // Source: Complete the "Clean Getaway" quest.
+      1244908294, // Source: Complete the "Loaded Question" quest from Zavala.
+      2317365255, // Source: Complete the "A Loud Racket" quest.
+      2537301256, // Source: Reach a Glory Rank of "Fabled" in the Crucible.
+      2883838366, // Source: Complete the "Breakneck" quest from the Drifter.
+    ],
+    searchString: [],
+  },
+  'weapon:ritual': {
+    itemHashes: [
+      805677041, // Buzzard
+      838556752, // Python
+      847329160, // Edgewise
+      1179141605, // Felwinter's Lie
+      1644680957, // Null Composure
+      2697058914, // Komodo-4FR
+      3434944005, // Point of the Stag
+      3535742959, // Randy's Throwing Knife
+      4184808992, // Adored
+      4227181568, // Exit Strategy
+    ],
+    sourceHashes: [
+      3299964501, // Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.
+      3348906688, // Source: Earn ranks in Vanguard strikes, Crucible, or Gambit.
+    ],
+    searchString: [],
+  },
   wellspring: {
     itemHashes: [],
     sourceHashes: [

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -970,6 +970,25 @@ const D2Sources: {
     ],
     searchString: [],
   },
+  'pinnacle-weapon': {
+    itemHashes: [
+      578459533, // Wendigo GL3
+      654608616, // Revoker
+      1584643826, // Hush
+      1600633250, // 21% Delirium
+      3354242550, // The Recluse
+      3907337522, // Oxygen SR3
+    ],
+    sourceHashes: [
+      598662729, // Source: Reach Glory Rank "Legend" in the Crucible.
+      1162859311, // Source: Complete the "Clean Getaway" quest.
+      1244908294, // Source: Complete the "Loaded Question" quest from Zavala.
+      2317365255, // Source: Complete the "A Loud Racket" quest.
+      2537301256, // Source: Reach a Glory Rank of "Fabled" in the Crucible.
+      2883838366, // Source: Complete the "Breakneck" quest from the Drifter.
+    ],
+    searchString: [],
+  },
   pit: {
     itemHashes: [],
     sourceHashes: [
@@ -1093,6 +1112,25 @@ const D2Sources: {
       3567813252, // Source: Season of the Seraph Triumph
       3574140916, // Source: Season of the Seraph
       3937492340, // Source: Complete Seraph bounties.
+    ],
+    searchString: [],
+  },
+  'ritual-weapon': {
+    itemHashes: [
+      805677041, // Buzzard
+      838556752, // Python
+      847329160, // Edgewise
+      1179141605, // Felwinter's Lie
+      1644680957, // Null Composure
+      2697058914, // Komodo-4FR
+      3434944005, // Point of the Stag
+      3535742959, // Randy's Throwing Knife
+      4184808992, // Adored
+      4227181568, // Exit Strategy
+    ],
+    sourceHashes: [
+      3299964501, // Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.
+      3348906688, // Source: Earn ranks in Vanguard strikes, Crucible, or Gambit.
     ],
     searchString: [],
   },
@@ -1468,44 +1506,6 @@ const D2Sources: {
     itemHashes: [],
     sourceHashes: [
       1597738585, // Source: "Spire of the Watcher" Dungeon
-    ],
-    searchString: [],
-  },
-  'weapon:pinnacle': {
-    itemHashes: [
-      578459533, // Wendigo GL3
-      654608616, // Revoker
-      1584643826, // Hush
-      1600633250, // 21% Delirium
-      3354242550, // The Recluse
-      3907337522, // Oxygen SR3
-    ],
-    sourceHashes: [
-      598662729, // Source: Reach Glory Rank "Legend" in the Crucible.
-      1162859311, // Source: Complete the "Clean Getaway" quest.
-      1244908294, // Source: Complete the "Loaded Question" quest from Zavala.
-      2317365255, // Source: Complete the "A Loud Racket" quest.
-      2537301256, // Source: Reach a Glory Rank of "Fabled" in the Crucible.
-      2883838366, // Source: Complete the "Breakneck" quest from the Drifter.
-    ],
-    searchString: [],
-  },
-  'weapon:ritual': {
-    itemHashes: [
-      805677041, // Buzzard
-      838556752, // Python
-      847329160, // Edgewise
-      1179141605, // Felwinter's Lie
-      1644680957, // Null Composure
-      2697058914, // Komodo-4FR
-      3434944005, // Point of the Stag
-      3535742959, // Randy's Throwing Knife
-      4184808992, // Adored
-      4227181568, // Exit Strategy
-    ],
-    sourceHashes: [
-      3299964501, // Source: Earn Ranks in Vanguard, Crucible, or Gambit playlists.
-      3348906688, // Source: Earn ranks in Vanguard strikes, Crucible, or Gambit.
     ],
     searchString: [],
   },


### PR DESCRIPTION
open to better names but this does work in autocomplete

`source:weapon:ritual`
`source:weapon:pinnacle`