### PR TITLE
Bump bungie-api-ts and d2api/manifest-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {},
   "devDependencies": {
     "@atao60/fse-cli": "^0.1.7",
-    "@d2api/manifest-node": "0.0.5",
+    "@d2api/manifest-node": "^2.0.0",
     "@hayes0724/web-font-converter": "^1.0.5",
     "@types/fs-extra": "^9.0.1",
     "@types/node": "^17.0.35",

--- a/src/generate-adept-weapon-hashes.ts
+++ b/src/generate-adept-weapon-hashes.ts
@@ -1,4 +1,4 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { DestinyItemType } from 'bungie-api-ts/destiny2';
 import { writeFile } from './helpers.js';
 
@@ -14,7 +14,7 @@ import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 const adeptStrings = ['(Adept)', '(Timelost)', '(Harrowed)'];
 const adeptWeaponHashes = inventoryItems
   .filter(

--- a/src/generate-bounty-data.ts
+++ b/src/generate-bounty-data.ts
@@ -1,4 +1,4 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { DestinyInventoryItemDefinition, DestinyRecordDefinition } from 'bungie-api-ts/destiny2';
 import { KillType, matchTable } from '../data/bounties/bounty-config.js';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
@@ -10,7 +10,7 @@ type AssignmentCategory = keyof BountyMetadata;
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const debug = false;
 const debugRecords = false;
@@ -34,7 +34,7 @@ const accessors = {
   obj: (item: DestinyInventoryItemDefinition) =>
     item.objectives?.objectiveHashes
       .map((o) => {
-        const obj = get('DestinyObjectiveDefinition', o);
+        const obj = getDef('Objective', o);
         return obj?.displayProperties?.name || obj?.progressDescription;
       })
       .join(),
@@ -48,7 +48,7 @@ const recordAccessors = {
   obj: (item: DestinyRecordDefinition) =>
     item.objectiveHashes
       ?.map((o) => {
-        const obj = get('DestinyObjectiveDefinition', o);
+        const obj = getDef('Objective', o);
         return obj?.displayProperties?.name || obj?.progressDescription;
       })
       .join(),
@@ -113,23 +113,17 @@ inventoryItems.forEach((inventoryItem) => {
       name: inventoryItem.displayProperties.name,
       description: inventoryItem.displayProperties.description,
       objectives: inventoryItem.objectives?.objectiveHashes.map((o) => {
-        const obj = get('DestinyObjectiveDefinition', o);
+        const obj = getDef('Objective', o);
         return obj?.displayProperties.name || obj?.progressDescription;
       }),
       type: inventoryItem.itemTypeAndTierDisplayName,
       label: inventoryItem.inventory?.stackUniqueLabel,
-      places: thisBounty.Destination?.map(
-        (p) => get('DestinyDestinationDefinition', p)?.displayProperties.name
-      ),
+      places: thisBounty.Destination?.map((p) => getDef('Destination', p)?.displayProperties.name),
       activities: thisBounty.ActivityMode?.map(
-        (a) => get('DestinyActivityModeDefinition', a)?.displayProperties.name
+        (a) => getDef('ActivityMode', a)?.displayProperties.name
       ),
-      dmg: thisBounty.DamageType?.map(
-        (a) => get('DestinyDamageTypeDefinition', a)?.displayProperties.name
-      ),
-      item: thisBounty.ItemCategory?.map(
-        (a) => get('DestinyItemCategoryDefinition', a)?.displayProperties.name
-      ),
+      dmg: thisBounty.DamageType?.map((a) => getDef('DamageType', a)?.displayProperties.name),
+      item: thisBounty.ItemCategory?.map((a) => getDef('ItemCategory', a)?.displayProperties.name),
       kill: thisBounty.KillType?.map((k) => KillType[k]),
     });
   }
@@ -138,7 +132,7 @@ inventoryItems.forEach((inventoryItem) => {
 writeFile('./output/pursuits.json', bounties, true);
 
 function flattenRecords(hash: number): number[] {
-  const node = get('DestinyPresentationNodeDefinition', hash);
+  const node = getDef('PresentationNode', hash);
 
   let records = node?.children.records.map((r) => r.recordHash) || [];
 
@@ -158,7 +152,7 @@ const recordHashes = flattenRecords(3443694067);
 
 const recordInfo: Record<string, BountyMetadata> = {};
 for (const recordHash of recordHashes) {
-  const record = get('DestinyRecordDefinition', recordHash);
+  const record = getDef('Record', recordHash);
 
   if (!record) {
     continue;
@@ -198,21 +192,15 @@ for (const recordHash of recordHashes) {
       name: record.displayProperties.name,
       description: record.displayProperties.description,
       objectives: record.objectiveHashes?.map((o) => {
-        const obj = get('DestinyObjectiveDefinition', o);
+        const obj = getDef('Objective', o);
         return obj?.displayProperties.name || obj?.progressDescription;
       }),
-      places: thisBounty.Destination?.map(
-        (p) => get('DestinyDestinationDefinition', p)?.displayProperties.name
-      ),
+      places: thisBounty.Destination?.map((p) => getDef('Destination', p)?.displayProperties.name),
       activities: thisBounty.ActivityMode?.map(
-        (a) => get('DestinyActivityModeDefinition', a)?.displayProperties.name
+        (a) => getDef('ActivityMode', a)?.displayProperties.name
       ),
-      dmg: thisBounty.DamageType?.map(
-        (a) => get('DestinyDamageTypeDefinition', a)?.displayProperties.name
-      ),
-      item: thisBounty.ItemCategory?.map(
-        (a) => get('DestinyItemCategoryDefinition', a)?.displayProperties.name
-      ),
+      dmg: thisBounty.DamageType?.map((a) => getDef('DamageType', a)?.displayProperties.name),
+      item: thisBounty.ItemCategory?.map((a) => getDef('ItemCategory', a)?.displayProperties.name),
       kill: thisBounty.KillType?.map((k) => KillType[k]),
     });
   }

--- a/src/generate-bright-engram-data.ts
+++ b/src/generate-bright-engram-data.ts
@@ -1,4 +1,4 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import seasons from '../data/seasons/seasons_unfiltered.json' assert { type: 'json' };
 import { D2CalculatedSeason } from './generate-season-info.js';
@@ -6,7 +6,7 @@ import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const brightEngramExclusions = [
   'Crimson',
@@ -31,7 +31,7 @@ inventoryItems.forEach((inventoryItem) => {
     !hasTerm(description, brightEngramExclusions) &&
     !hasTerm(name, brightEngramExclusions) &&
     // and there's a corresponding vendor table for this hash
-    get('DestinyVendorDefinition', hash)
+    getDef('Vendor', hash)
   ) {
     // get this specific item's season
     const season = seasons[hash as unknown as keyof typeof seasons];

--- a/src/generate-craftable-hashes.ts
+++ b/src/generate-craftable-hashes.ts
@@ -1,9 +1,9 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { uniqAndSortArray, writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const craftableHashes = inventoryItems
   .filter((i) => i.crafting)

--- a/src/generate-crafting-enhanced-intrinsics.ts
+++ b/src/generate-crafting-enhanced-intrinsics.ts
@@ -2,26 +2,26 @@
  * Collect enhanced intrinsics for craftable weapons so that we can treat
  * their bonus stats correctly.
  */
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { PlugCategoryHashes } from '../data/generated-enums.js';
 import { annotate, writeFile } from './helpers.js';
 
 loadLocal();
 const allEnhancedIntrinsics: number[] = [];
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 for (const pattern of inventoryItems.filter((i) => i.crafting)) {
   const frameSocket = pattern.sockets?.socketEntries.find((s) =>
-    get('DestinySocketTypeDefinition', s.socketTypeHash)?.plugWhitelist.some(
+    getDef('SocketType', s.socketTypeHash)?.plugWhitelist.some(
       (w) => w.categoryHash === PlugCategoryHashes.Intrinsics
     )
   );
   if (frameSocket?.reusablePlugSetHash) {
-    const plugSet = get('DestinyPlugSetDefinition', frameSocket.reusablePlugSetHash);
+    const plugSet = getDef('PlugSet', frameSocket.reusablePlugSetHash);
     const enhancedIntrinsics = plugSet?.reusablePlugItems
       .filter((p) =>
-        get('DestinyInventoryItemDefinition', p.plugItemHash)?.investmentStats.some(
+        getDef('InventoryItem', p.plugItemHash)?.investmentStats.some(
           (s) => s.isConditionallyActive
         )
       )

--- a/src/generate-crafting-mementos.ts
+++ b/src/generate-crafting-mementos.ts
@@ -1,7 +1,7 @@
 /**
  * Collect mementos by their source.
  */
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { PlugCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
 
@@ -9,7 +9,7 @@ loadLocal();
 const mementosBySource: Record<string, number[]> = {};
 const mementoRegex = /^([\w\s]+) Memento$/;
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 for (const memento of inventoryItems.filter(
   (i) => i.plug?.plugCategoryHash === PlugCategoryHashes.Mementos

--- a/src/generate-deprecated-mods.ts
+++ b/src/generate-deprecated-mods.ts
@@ -1,9 +1,9 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 function findAllDeprecatedMods() {
   const deprecatedModHashes = new Set<number>();

--- a/src/generate-empty-plugs.ts
+++ b/src/generate-empty-plugs.ts
@@ -3,14 +3,14 @@
  * so we can pick a correct empty plug where singleInitialItemHash is
  * insufficient.
  */
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
 const emptySocketRegex = /^(Default .*|.* Socket)$/;
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const emptyPlugs = inventoryItems
   .filter((i) => i.plug)

--- a/src/generate-engram-rarity-icons.ts
+++ b/src/generate-engram-rarity-icons.ts
@@ -1,11 +1,11 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
 const results: NodeJS.Dict<string> = {};
-for (const i of getAll('DestinyInventoryItemDefinition')) {
+for (const i of getAllDefs('InventoryItem')) {
   if (
     // if it's filled in we're done
     !results[i.inventory!.tierTypeName] &&
@@ -14,7 +14,7 @@ for (const i of getAll('DestinyInventoryItemDefinition')) {
     // whose name starts with a rarity name string
     i.displayProperties.name.startsWith(i.inventory!.tierTypeName) &&
     // engrams that correspond to a vendor, for max hash stability
-    get('DestinyVendorDefinition', i.hash)
+    getDef('Vendor', i.hash)
   ) {
     results[i.inventory!.tierTypeName] = i.displayProperties.icon;
   }

--- a/src/generate-enums.ts
+++ b/src/generate-enums.ts
@@ -1,4 +1,4 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import {
   BucketCategoryLookup,
   DestinyItemSubTypeLookup,
@@ -18,7 +18,7 @@ const socketCategoryDescriptionDiscriminator = ['Ikora', 'Stranger', 'Neomuna'];
 
 const generatedEnums: Record<string, Record<string, number>> = {};
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 generatedEnums.PlugCategoryHashes = {};
 inventoryItems.forEach((item) => {
   if (item.plug && !item.redacted) {
@@ -27,12 +27,12 @@ inventoryItems.forEach((item) => {
   }
 });
 
-const allStats = getAll('DestinyStatDefinition');
-const allItemCategories = getAll('DestinyItemCategoryDefinition');
-const allSocketCategories = getAll('DestinySocketCategoryDefinition');
-const allBuckets = getAll('DestinyInventoryBucketDefinition');
-const allBreakers = getAll('DestinyBreakerTypeDefinition');
-const someProgressions = getAll('DestinyProgressionDefinition').filter((i) => i.rankIcon);
+const allStats = getAllDefs('Stat');
+const allItemCategories = getAllDefs('ItemCategory');
+const allSocketCategories = getAllDefs('SocketCategory');
+const allBuckets = getAllDefs('InventoryBucket');
+const allBreakers = getAllDefs('BreakerType');
+const someProgressions = getAllDefs('Progression').filter((i) => i.rankIcon);
 
 const enumSources = [
   { name: 'StatHashes', data: allStats },

--- a/src/generate-event-info.ts
+++ b/src/generate-event-info.ts
@@ -1,4 +1,4 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import crimsondays from '../data/events/crimsondays.json' assert { type: 'json' };
 import dawning from '../data/events/dawning.json' assert { type: 'json' };
 import eventDenyList from '../data/events/deny-list.json' assert { type: 'json' };
@@ -12,8 +12,8 @@ import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
-const vendors = getAll('DestinyVendorDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
+const vendors = getAllDefs('Vendor');
 
 const eventInfo: Record<
   number,
@@ -90,8 +90,7 @@ inventoryItems.forEach((item) => {
     return;
   }
   const eventID = events[eventName];
-  const collectibleHash =
-    get('DestinyCollectibleDefinition', item.collectibleHash)?.sourceHash ?? -99999999;
+  const collectibleHash = getDef('Collectible', item.collectibleHash)?.sourceHash ?? -99999999;
 
   // skip this item if
   if (
@@ -146,13 +145,13 @@ vendors
     // for each item this event engram contains
     Object.values(engram.itemList).forEach(function (listItem) {
       // fetch its inventory
-      const item = get('DestinyInventoryItemDefinition', listItem.itemHash)!;
+      const item = getDef('InventoryItem', listItem.itemHash)!;
 
       // various deny list reasons to skip including this item
       if (
         // it already has an event source
         sourcedItems.includes(
-          get('DestinyCollectibleDefinition', item.collectibleHash)?.sourceHash ?? -99999999
+          getDef('Collectible', item.collectibleHash)?.sourceHash ?? -99999999
         ) ||
         // it's a category we don't include
         (item.itemCategoryHashes &&

--- a/src/generate-extended-breaker.ts
+++ b/src/generate-extended-breaker.ts
@@ -1,10 +1,10 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { BreakerTypeHashes, SocketCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const extendedBreakers: Record<number, number> = {};
 
@@ -16,8 +16,8 @@ inventoryItems.filter(
       if ([SocketCategoryHashes.IntrinsicTraits, 965959289].includes(socket.socketTypeHash)) {
         let extendedBreaker = 0;
         const intrinsicTraitDescription =
-          get(
-            'DestinyInventoryItemDefinition',
+          getDef(
+            'InventoryItem',
             socket.singleInitialItemHash
           )?.displayProperties.description.toLowerCase() ?? '';
         if (/shield-piercing|disrupt|overload|stagger/.test(intrinsicTraitDescription)) {

--- a/src/generate-extended-foundry.ts
+++ b/src/generate-extended-foundry.ts
@@ -1,10 +1,10 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes, SocketCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const extendedFoundry: Record<number, string> = {};
 
@@ -93,7 +93,7 @@ function fixMismatchIconFoundry(foundry: string) {
         ) {
           const hash = item.hash;
           const foundryOriginTrait =
-            get('DestinyPlugSetDefinition', socket.reusablePlugSetHash)
+            getDef('PlugSet', socket.reusablePlugSetHash)
               ?.reusablePlugItems.map((i) => i.plugItemHash)
               .filter((hashes) => foundryOriginTraitHashes.includes(hashes)) ?? [];
 

--- a/src/generate-extended-ich.ts
+++ b/src/generate-extended-ich.ts
@@ -1,10 +1,10 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const ffGrenadeLaunchers = inventoryItems.filter(
   (item) =>

--- a/src/generate-ghost-data.ts
+++ b/src/generate-ghost-data.ts
@@ -1,10 +1,10 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const ghostPerks: Record<
   string,

--- a/src/generate-masterworks-with-cond-stats.ts
+++ b/src/generate-masterworks-with-cond-stats.ts
@@ -3,12 +3,12 @@
  * stats associated with them.
  */
 
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 const masterworkPlugsWithCondStats = inventoryItems
   .filter(
     (i) =>

--- a/src/generate-missing-collectible-info.ts
+++ b/src/generate-missing-collectible-info.ts
@@ -1,4 +1,4 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import stringifyObject from 'stringify-object';
 import _categories from '../data/sources/categories.json' assert { type: 'json' };
 import {
@@ -14,8 +14,8 @@ const categories: Categories = _categories;
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
-const collectibles = getAll('DestinyCollectibleDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
+const collectibles = getAllDefs('Collectible');
 
 const hashToMissingCollectibleHash: Record<string, number> = {};
 

--- a/src/generate-missing-faction-tokens.ts
+++ b/src/generate-missing-faction-tokens.ts
@@ -1,10 +1,10 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { uniqAndSortArray, writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
-const factions = getAll('DestinyFactionDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
+const factions = getAllDefs('Faction');
 
 const tokenHashes: any = [];
 factions.forEach(({ tokenValues }) => {

--- a/src/generate-mod-cost-reductions.ts
+++ b/src/generate-mod-cost-reductions.ts
@@ -1,10 +1,10 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const normalToReducedMod: { [normalModHash: number]: number } = {};
 

--- a/src/generate-mod-slot-data.ts
+++ b/src/generate-mod-slot-data.ts
@@ -1,4 +1,4 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import stringifyObject from 'stringify-object';
 import { D2CalculatedSeason } from './generate-season-info.js';
@@ -6,7 +6,7 @@ import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const namedSeasonExceptions: Record<number, string> = {
   420: 'outlaw',
@@ -73,11 +73,8 @@ const modMetadatas: ModSocketMetadata[] = emptySeasonalModSockets
     }
     // all mods that could go into this empty mod socket
     const compatibleTags = arrayUniq(
-      get(
-        'DestinyPlugSetDefinition',
-        exampleArmorSocketEntry?.reusablePlugSetHash
-      )?.reusablePlugItems.map((plugItem) =>
-        seasonTagFromMod(get('DestinyInventoryItemDefinition', plugItem.plugItemHash)!)
+      getDef('PlugSet', exampleArmorSocketEntry?.reusablePlugSetHash)?.reusablePlugItems.map(
+        (plugItem) => seasonTagFromMod(getDef('InventoryItem', plugItem.plugItemHash)!)
       ) || []
     );
 
@@ -93,10 +90,9 @@ const modMetadatas: ModSocketMetadata[] = emptySeasonalModSockets
     );
 
     // plugCategoryHashes supported by this SocketType
-    const compatiblePlugCategoryHashes = get(
-      'DestinySocketTypeDefinition',
-      socketTypeHash
-    )!.plugWhitelist.map((plugType) => plugType.categoryHash);
+    const compatiblePlugCategoryHashes = getDef('SocketType', socketTypeHash)!.plugWhitelist.map(
+      (plugType) => plugType.categoryHash
+    );
 
     return {
       season,

--- a/src/generate-objective-to-triumph.ts
+++ b/src/generate-objective-to-triumph.ts
@@ -1,11 +1,11 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
-const records = getAll('DestinyRecordDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
+const records = getAllDefs('Record');
 
 const debug = false || process.env.CI;
 // e.g. 'Complete Crucible Triumph "The Stuff of Myth."';

--- a/src/generate-perk-names-for-voiceDIM.ts
+++ b/src/generate-perk-names-for-voiceDIM.ts
@@ -1,10 +1,10 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { PlugCategoryHashes } from '../data/generated-enums.js';
 import { uniqAndSortArray, writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const plugs = [
   PlugCategoryHashes.Barrels,

--- a/src/generate-powerful-rewards.ts
+++ b/src/generate-powerful-rewards.ts
@@ -1,10 +1,10 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { uniqAndSortArray, writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
-const milestones = getAll('DestinyMilestoneDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
+const milestones = getAllDefs('Milestone');
 
 const rewards: number[] = [];
 const rewardHash = 326786556;

--- a/src/generate-raid-mods.ts
+++ b/src/generate-raid-mods.ts
@@ -1,12 +1,12 @@
 /**
  * Collect all the raid mod plug category hashes.
  */
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { uniqAndSortArray, writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 const lastWishRaidModPlugCategoryIdentifier = 'enhancements.season_outlaw';
 const raidModPlugCategoryIdentifier = 'enhancements.raid_';
 

--- a/src/generate-rich-text-objective.ts
+++ b/src/generate-rich-text-objective.ts
@@ -1,11 +1,11 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import stringifyObject from 'stringify-object';
 import { sortObject, writeFile } from './helpers.js';
 
 loadLocal();
 
-const objectives = getAll('DestinyObjectiveDefinition');
-const perks = getAll('DestinySandboxPerkDefinition');
+const objectives = getAllDefs('Objective');
+const perks = getAllDefs('SandboxPerk');
 
 const iconFinder = /(\[[^\]]+\]|[\uE000-\uF8FF])/g;
 

--- a/src/generate-season-info.ts
+++ b/src/generate-season-info.ts
@@ -229,9 +229,9 @@ function formatDateDDMMMYYYY(dateString: string, dayBefore = false) {
   if (dayBefore) {
     date.setDate(date.getDate() - 1);
   }
-  const day = date.toLocaleString('default', { day: '2-digit' });
-  const year = date.toLocaleString('default', { year: 'numeric' });
-  const month = date.toLocaleString('default', { month: 'short' }).toUpperCase();
+  const day = date.toLocaleString('en-US', { day: '2-digit' });
+  const year = date.toLocaleString('en-US', { year: 'numeric' });
+  const month = date.toLocaleString('en-US', { month: 'short' }).toUpperCase();
   return `${day}${month}${year}`;
 }
 

--- a/src/generate-season-info.ts
+++ b/src/generate-season-info.ts
@@ -1,4 +1,4 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import stringifyObject from 'stringify-object';
 import { D2SeasonInfo } from '../data/seasons/d2-season-info-static.js';
 import seasons from '../data/seasons/seasons_unfiltered.json' assert { type: 'json' };
@@ -9,7 +9,7 @@ loadLocal();
 export const D2CalculatedSeason: number = getCurrentSeason();
 
 const powerCaps = new Set(
-  getAll('DestinyPowerCapDefinition')
+  getAllDefs('PowerCap')
     .map((p) => p.powerCap)
     .filter((p) => p > 1000 && p < 50000)
     .sort((a, b) => a - b)
@@ -46,9 +46,7 @@ const seasonOverrides: Record<
 };
 
 // Sort seasons in numerical order for use in the below for/next
-const seasonDefs = getAll('DestinySeasonDefinition').sort((a, b) =>
-  a.seasonNumber > b.seasonNumber ? 1 : -1
-);
+const seasonDefs = getAllDefs('Season').sort((a, b) => (a.seasonNumber > b.seasonNumber ? 1 : -1));
 
 let seasonsMD = ``;
 for (let season = 7; season < seasonDefs.length; season++) {
@@ -110,7 +108,7 @@ export const D2CalculatedSeason = ${D2CalculatedSeason};`;
 const D2SeasonInfoAnnotated = annotate(pretty);
 writeFile('./output/d2-season-info.ts', D2SeasonInfoAnnotated);
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 inventoryItems.forEach((inventoryItem) => {
   const { hash } = inventoryItem;
@@ -173,7 +171,7 @@ writeFile('./SEASONS.md', `${seasonMDInfo.header}${seasonsMD}${seasonMDInfo.foot
 
 function getCurrentSeason() {
   // Sort Seasons backwards and return the first season without a valid end date
-  const seasonDefs = getAll('DestinySeasonDefinition').sort((a, b) =>
+  const seasonDefs = getAllDefs('Season').sort((a, b) =>
     a.seasonNumber > b.seasonNumber ? 1 : -1
   );
   for (let season = seasonDefs.length - 1; season > 0; season--) {

--- a/src/generate-season-to-source.ts
+++ b/src/generate-season-to-source.ts
@@ -1,4 +1,4 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import seasonsUnfiltered from '../data/seasons/seasons_unfiltered.json' assert { type: 'json' };
 import { D2CalculatedSeason } from './generate-season-info.js';
@@ -6,7 +6,7 @@ import { writeFile } from './helpers.js';
 
 loadLocal();
 
-let inventoryItems = getAll('DestinyInventoryItemDefinition');
+let inventoryItems = getAllDefs('InventoryItem');
 
 // init an array in seasonNumbers for each season
 const seasonNumbers = [...Array(D2CalculatedSeason + 1).keys()].slice(1);
@@ -19,7 +19,7 @@ const itemSource: Record<number, number> = {};
 // loop through collectibles
 inventoryItems.forEach(function (item) {
   const sourceHash = item.collectibleHash
-    ? get('DestinyCollectibleDefinition', item.collectibleHash)?.sourceHash
+    ? getDef('Collectible', item.collectibleHash)?.sourceHash
     : null;
   const season = (seasonsUnfiltered as Record<string, number>)[item.hash];
   if (sourceHash && season) {

--- a/src/generate-season-watermark-backup.ts
+++ b/src/generate-season-watermark-backup.ts
@@ -1,11 +1,11 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import seasons from '../data/seasons/seasons_unfiltered.json' assert { type: 'json' };
 import watermarkToSeason from '../output/watermark-to-season.json' assert { type: 'json' };
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 const backupData: Record<string, number> = {};
 
 inventoryItems.forEach((inventoryItem) => {

--- a/src/generate-source-info.ts
+++ b/src/generate-source-info.ts
@@ -1,4 +1,4 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import stringifyObject from 'stringify-object';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import categories_ from '../data/sources/categories.json' assert { type: 'json' };
@@ -15,9 +15,9 @@ const categories: Categories = categories_;
 // get the manifest data ready
 loadLocal();
 
-const allInventoryItems = getAll('DestinyInventoryItemDefinition');
-const allCollectibles = getAll('DestinyCollectibleDefinition');
-const allPresentationNodes = getAll('DestinyPresentationNodeDefinition');
+const allInventoryItems = getAllDefs('InventoryItem');
+const allCollectibles = getAllDefs('Collectible');
+const allPresentationNodes = getAllDefs('PresentationNode');
 
 /**
  * this is just a hash-to-sourceString conversion table,
@@ -120,10 +120,7 @@ for (const [sourceTag, matchRule] of Object.entries(categories.sources)) {
     );
     for (const foundPresentationNode of foundPresentationNodes) {
       for (const collectible of foundPresentationNode.children.collectibles) {
-        const childItemHash = get(
-          'DestinyCollectibleDefinition',
-          collectible.collectibleHash
-        )?.itemHash;
+        const childItemHash = getDef('Collectible', collectible.collectibleHash)?.itemHash;
         childItemHash && itemHashes.push(childItemHash);
       }
     }

--- a/src/generate-spider-mats.ts
+++ b/src/generate-spider-mats.ts
@@ -1,4 +1,4 @@
-import { get, loadLocal } from '@d2api/manifest-node';
+import { getDef, loadLocal } from '@d2api/manifest-node';
 import { uniqAndSortArray, writeFile } from './helpers.js';
 
 loadLocal();
@@ -19,12 +19,12 @@ const DENY_HASHES = [1022552290];
 const GLIMMER_HASHES = [3159615086, 3664001560];
 const indexFixList = ['Phaseglass Needle', 'Baryon Bough'];
 
-const rahool = get('DestinyVendorDefinition', 2255782930);
+const rahool = getDef('Vendor', 2255782930);
 
 rahool?.itemList.flatMap((i) => {
   if (GLIMMER_HASHES.includes(i.itemHash)) {
     if (!DENY_HASHES.includes(i.currencies[0].itemHash)) {
-      const item = get('DestinyInventoryItemDefinition', i.currencies[0].itemHash)!;
+      const item = getDef('InventoryItem', i.currencies[0].itemHash)!;
       const hash = item.hash;
       const name = item.displayProperties.name;
       const index = item.index;
@@ -67,17 +67,13 @@ const validRahoolCurrencies = [
   ...new Set(
     rahool?.itemList.flatMap((i) =>
       i.currencies.map(
-        (c) =>
-          [
-            c.itemHash,
-            get('DestinyInventoryItemDefinition', c.itemHash)?.displayProperties.name,
-          ] as const
+        (c) => [c.itemHash, getDef('InventoryItem', c.itemHash)?.displayProperties.name] as const
       )
     ) ?? []
   ),
 ];
 const purchaseableCurrencyItems = rahool?.itemList.filter((i) => {
-  const def = get('DestinyInventoryItemDefinition', i.itemHash)?.displayProperties.name;
+  const def = getDef('InventoryItem', i.itemHash)?.displayProperties.name;
   if (
     def?.startsWith('Purchase ') &&
     validRahoolCurrencies.find(
@@ -90,7 +86,7 @@ const purchaseableCurrencyItems = rahool?.itemList.filter((i) => {
 });
 const purchaseableMatTable: NodeJS.Dict<number> = {};
 purchaseableCurrencyItems?.forEach((i) => {
-  const def = get('DestinyInventoryItemDefinition', i.itemHash)!.displayProperties.name;
+  const def = getDef('InventoryItem', i.itemHash)!.displayProperties.name;
   purchaseableMatTable[i.itemHash] = validRahoolCurrencies.find(
     ([, matName]) =>
       matName?.includes(def.replace('Purchase ', '')) || (matName && def.includes(matName))

--- a/src/generate-subclass-plug-category-hashes.ts
+++ b/src/generate-subclass-plug-category-hashes.ts
@@ -3,15 +3,15 @@
  * abilities, aspects, and fragments found on subclasses with
  * pluggable sockets.
  */
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { uniqAndSortArray, writeFile } from './helpers.js';
 
 loadLocal();
 
-const getItem = (hash: number) => get('DestinyInventoryItemDefinition', hash);
-const getPlugSet = (hash: number) => get('DestinyPlugSetDefinition', hash);
+const getItem = (hash: number) => getDef('InventoryItem', hash);
+const getPlugSet = (hash: number) => getDef('PlugSet', hash);
 
-const allItems = getAll('DestinyInventoryItemDefinition');
+const allItems = getAllDefs('InventoryItem');
 
 const classBucketHash = 3284755031;
 

--- a/src/generate-symbols.ts
+++ b/src/generate-symbols.ts
@@ -1,4 +1,4 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { FontGlyphs } from '../data/d2-font-glyphs.js';
 import { writeFile } from './helpers.js';
 
@@ -142,11 +142,11 @@ interface Source {
 
 loadLocal();
 
-const traits = getAll('DestinyTraitDefinition');
-const items = getAll('DestinyInventoryItemDefinition');
-const perks = getAll('DestinySandboxPerkDefinition');
-const activities = getAll('DestinyActivityModeDefinition');
-const objectives = getAll('DestinyObjectiveDefinition');
+const traits = getAllDefs('Trait');
+const items = getAllDefs('InventoryItem');
+const perks = getAllDefs('SandboxPerk');
+const activities = getAllDefs('ActivityMode');
+const objectives = getAllDefs('Objective');
 
 // First, index all rich text data from the defs
 type fromRichTextManifestSourceData = Record<

--- a/src/generate-trait-enhanced-trait-lookup.ts
+++ b/src/generate-trait-enhanced-trait-lookup.ts
@@ -1,7 +1,7 @@
 /**
  * Generates an invertible base trait -> enhanced trait mapping.
  */
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { DestinyInventoryItemDefinition, TierType } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from '../data/generated-enums.js';
 import { writeFile } from './helpers.js';
@@ -42,17 +42,17 @@ const matchTraits = (plugs: DestinyInventoryItemDefinition[]) => {
   });
 };
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 // Prefer corresponding traits that come directly from the recipes, as they're certainly correct
 const craftingRecipes = inventoryItems.filter((i) => i.crafting);
 for (const recipe of craftingRecipes) {
   for (const socket of recipe.sockets!.socketEntries) {
     if (socket.reusablePlugSetHash) {
-      const plugSet = get('DestinyPlugSetDefinition', socket.reusablePlugSetHash);
+      const plugSet = getDef('PlugSet', socket.reusablePlugSetHash);
       if (plugSet) {
-        const plugs = plugSet.reusablePlugItems
-          .map((i) => get('DestinyInventoryItemDefinition', i.plugItemHash))
+        const plugs: DestinyInventoryItemDefinition[] = plugSet.reusablePlugItems
+          .map((i) => getDef('InventoryItem', i.plugItemHash))
           .filter((p) => p)
           .map((p) => p!);
         matchTraits(plugs);

--- a/src/generate-trials-objectives.ts
+++ b/src/generate-trials-objectives.ts
@@ -1,10 +1,10 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { DestinyItemType } from 'bungie-api-ts/destiny2';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const trialsObjectives: Record<number, string> = {};
 const trialsPassages = new Set<number>();
@@ -19,7 +19,7 @@ inventoryItems.forEach((inventoryItem) => {
     trialsPassages.add(inventoryItem.hash);
     //Now pull out each objective if we have any
     inventoryItem.objectives?.objectiveHashes.forEach((o) => {
-      const obj = get('DestinyObjectiveDefinition', o);
+      const obj = getDef('Objective', o);
       if (obj) {
         if (obj.progressDescription === 'Flawless') {
           if (obj.completedValueStyle === 10) {

--- a/src/generate-universal-ornament-plugsethashes.ts
+++ b/src/generate-universal-ornament-plugsethashes.ts
@@ -1,7 +1,7 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { writeFile } from './helpers.js';
 
-const plugSets = getAll('DestinyPlugSetDefinition');
+const plugSets = getAllDefs('PlugSet');
 // 5 slots x 3 classes
 const expectedNumber = 15;
 
@@ -10,7 +10,7 @@ loadLocal();
 const ornamentPlugSetHashes: number[] = [];
 // Universal ornament PlugSets have quite a few items in them
 for (const plugSet of plugSets.filter((s) => s.reusablePlugItems?.length > 100)) {
-  const item = get('DestinyInventoryItemDefinition', plugSet.reusablePlugItems[0].plugItemHash);
+  const item = getDef('InventoryItem', plugSet.reusablePlugItems[0].plugItemHash);
   if (item?.plug?.plugCategoryIdentifier.startsWith('armor_skins')) {
     ornamentPlugSetHashes.push(plugSet.hash);
   }

--- a/src/generate-watermark-info.ts
+++ b/src/generate-watermark-info.ts
@@ -1,4 +1,4 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import seasons from '../data/seasons/seasons_unfiltered.json' assert { type: 'json' };
 import { diffArrays, uniqAndSortArray, writeFile } from './helpers.js';
@@ -6,7 +6,7 @@ loadLocal();
 
 // Unhelpful watermark
 const IGNORED_WATERMARKS = ['/common/destiny2_content/icons/64e07aa12c7c9956ee607ccb5b3c6718.png'];
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 const allWatermarks = getAllWatermarks();
 
 let unassignedWatermarks = diffArrays(allWatermarks, IGNORED_WATERMARKS);
@@ -140,7 +140,7 @@ function getAllWatermarks() {
 // Generate Watermarks for Seasons based off of Season Pass Rewards
 //=============================================================================
 function findWatermarksViaSeasonPass() {
-  const seasonDefs = getAll('DestinySeasonDefinition').sort((a, b) =>
+  const seasonDefs = getAllDefs('Season').sort((a, b) =>
     a.seasonNumber > b.seasonNumber ? 1 : -1
   );
 
@@ -148,10 +148,10 @@ function findWatermarksViaSeasonPass() {
     if (seasonDefs[season].displayProperties.name.includes('[Redacted]')) {
       break;
     }
-    const rewardDef = get(
-      'DestinyProgressionDefinition',
-      get('DestinySeasonPassDefinition', seasonDefs[season].seasonPassHash)?.rewardProgressionHash
-    )?.rewardItems.map((item) => get('DestinyInventoryItemDefinition', item.itemHash))[0];
+    const rewardDef = getDef(
+      'Progression',
+      getDef('SeasonPass', seasonDefs[season].seasonPassHash)?.rewardProgressionHash
+    )?.rewardItems.map((item) => getDef('InventoryItem', item.itemHash))[0];
 
     const seasonalWatermarks = [
       rewardDef?.iconWatermark,

--- a/src/generate-weapons-from-quest.ts
+++ b/src/generate-weapons-from-quest.ts
@@ -1,10 +1,10 @@
-import { get, getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, getDef, loadLocal } from '@d2api/manifest-node';
 import { ItemCategoryHashes } from '../data/generated-enums.js';
 import { uniqAndSortArray, writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
 
 const weaponHashToQuestHash: any = { weaponHash: Number, questHash: Number };
 
@@ -27,7 +27,7 @@ const allWeaponQuests = uniqAndSortArray(
 );
 
 allWeaponQuests.forEach((qHash) => {
-  const questInfo = get('DestinyInventoryItemDefinition', qHash);
+  const questInfo = getDef('InventoryItem', qHash);
   const weaponRewardHash = questInfo?.value?.itemValue.filter((rewards) =>
     allWeaponsHashes.includes(rewards.itemHash)
   )[0]?.itemHash;

--- a/src/generate-workaround-items.ts
+++ b/src/generate-workaround-items.ts
@@ -1,10 +1,10 @@
-import { getAll, loadLocal } from '@d2api/manifest-node';
+import { getAllDefs, loadLocal } from '@d2api/manifest-node';
 import { writeFile } from './helpers.js';
 
 loadLocal();
 
-const inventoryItems = getAll('DestinyInventoryItemDefinition');
-const collectibles = getAll('DestinyCollectibleDefinition');
+const inventoryItems = getAllDefs('InventoryItem');
+const collectibles = getAllDefs('Collectible');
 
 const itemReplacementTable: Record<number, number> = {};
 

--- a/src/getD2Manifest.ts
+++ b/src/getD2Manifest.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import manifest from '@d2api/manifest-node';
+import { load, setApiKey } from '@d2api/manifest-node';
 
-manifest.setApiKey(process.env.API_KEY);
-manifest.load();
+setApiKey(process.env.API_KEY);
+load();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,7 +4,7 @@
 ||
 ||
 \*================================================================================================================================*/
-import { get, loadLocal } from '@d2api/manifest-node';
+import { getDef, loadLocal } from '@d2api/manifest-node';
 import { execSync } from 'child_process';
 import fetch from 'cross-fetch';
 import { writeFile as writeFileFS } from 'fs';
@@ -80,7 +80,7 @@ export function annotate(fileString: string, table?: Record<number, string>) {
   return fileString.replace(maybeHash, (_, prefix, hash, suffix) => {
     const comment = (
       table?.[hash] ??
-      get('DestinyInventoryItemDefinition', hash)?.displayProperties.name ??
+      getDef('InventoryItem', hash)?.displayProperties.name ??
       ''
     ).replace(/\n/gm, '\\n');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,9 +48,9 @@
     regenerator-runtime "^0.13.4"
 
 "@d2api/manifest-node@^2.0.0":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@d2api/manifest-node/-/manifest-node-2.0.5.tgz#2f5f693a2939b5e0b1021f7851c45522c94d4e79"
-  integrity sha512-nssRJWypShnT5Az2tf2bey1LiK8acObFGOXux/759uuUbDe6PuONC5AEndAduIt3AR28DvQEMcn8zgFYSlxNUw==
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@d2api/manifest-node/-/manifest-node-2.0.6.tgz#6e7bb41579bd5d99a9a66b1f6c715173ae004043"
+  integrity sha512-OGQ1hNZCW3FLVtlzQ1pFYoc7T+qoLCSWzEFTPn/0Cp/XeMo4XaqSkVBU9ZmaaL0oVNLJgmDr5Km5wIeHUz96LA==
   dependencies:
     "@d2api/manifest" "^5.1.1"
     bungie-api-ts "^4.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,19 +47,18 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@d2api/manifest-node@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@d2api/manifest-node/-/manifest-node-0.0.5.tgz#6cf92816ac5c75acb279a5c4fb2b616ebc5d7e7a"
-  integrity sha512-2s0hZb7B3z+Wv33hj9pEvhFnE2tPaOz2Fm4NfL0Q+4yMb9VPwc522bCn0iGhtVrXkncPNT0n1+/tRAw5v5/gzg==
+"@d2api/manifest-node@^2.0.0":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@d2api/manifest-node/-/manifest-node-2.0.5.tgz#2f5f693a2939b5e0b1021f7851c45522c94d4e79"
+  integrity sha512-nssRJWypShnT5Az2tf2bey1LiK8acObFGOXux/759uuUbDe6PuONC5AEndAduIt3AR28DvQEMcn8zgFYSlxNUw==
   dependencies:
-    "@d2api/manifest" "^2.0.0"
+    "@d2api/manifest" "^5.1.1"
+    bungie-api-ts "^4.21.0"
 
-"@d2api/manifest@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@d2api/manifest/-/manifest-2.0.0.tgz#4ec466a404906eac9f1968bc46fd011602e1241d"
-  integrity sha512-QduZyTMz+kZRwk52RgQ2gMut6RGdPg3paqgNyPV0EhFsUqJhu+p/CPwWjnInsVDqvAY/fnneMWGDqNf4HpIprQ==
-  dependencies:
-    bungie-api-ts "^4.3.0"
+"@d2api/manifest@^5.1.1":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@d2api/manifest/-/manifest-5.1.3.tgz#ee2d64598365443a549cae0b55ce6c525b296d4d"
+  integrity sha512-8scknb16aVbbfcVBxwakAB8bDNdZARECra+OidNFcJQ8x9Vog3X4vuIw5V5C0k7N81/fgqrY2wfESdWvbL9o2w==
 
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
@@ -499,10 +498,10 @@ bufferstreams@^2.0.1:
   dependencies:
     readable-stream "^2.3.6"
 
-bungie-api-ts@*, bungie-api-ts@^4.3.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/bungie-api-ts/-/bungie-api-ts-4.16.0.tgz#6906008704537f20d1e0c04cc2fe30e7e3c41903"
-  integrity sha512-oJ8jjWIRAaaq6L1tOL0DoS2HuDsdMpxnVsUqed+yR46AU0Q5PY6BanlsIXClPV9bN0b4PudcNqaheB5wHMsSQA==
+bungie-api-ts@*, bungie-api-ts@^4.21.0:
+  version "4.22.2"
+  resolved "https://registry.yarnpkg.com/bungie-api-ts/-/bungie-api-ts-4.22.2.tgz#91b32af6556bff2c750e829ead01b954640dcbb7"
+  integrity sha512-lOgV7K4ejivK7/voYME+3bgdNKK+XdjM42qflfnVEabCshwwwldb/DyNCg9IUjG3TZeGXxqjDECOW6OIM9b+VQ==
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
I want the new `bungie-api-ts` for the updated `DamageType` enum. Bumping our dependency on `bungie-api-ts` without bumping `d2api/manifest(-node)`'s dependency on `bungie-api-ts` results in incompatible Bungie types, while bumping `d2api/manifest(-node)`'s dependency on `bungie-api-ts` too results in a build error in `d2api/manifest(-node)` due to it not covering all new table types.

So the only option is bumping `d2api/manifest-node`, which means some API changes.