### PR TITLE
Generate artifact mod unlocks

### DIFF
--- a/data/artifact-mod-unlocks.ts
+++ b/data/artifact-mod-unlocks.ts
@@ -1,0 +1,47 @@
+export const artifactPlugUnlocks: { [artifactModHash: number]: number[] } = {
+  '3555350688': [
+    2283894334, // Solar Weapon Surge
+    3675553168, // Solar Holster
+    56663992, // Solar Scavenger
+    1086997255, // Solar Siphon
+    331268185, // Solar Targeting
+    1019574576, // Unflinching Solar Aim
+    411014648, // Solar Reserves
+    634608391, // Solar Loader
+    531665167, // Solar Dexterity
+  ],
+  '3555350690': [
+    3914973263, // Void Weapon Surge
+    2634786903, // Void Holster
+    2815817957, // Void Scavenger
+    1210012576, // Void Siphon
+    2888195476, // Void Targeting
+    3887037435, // Unflinching Void Aim
+    2413278875, // Void Reserves
+    3224649746, // Void Loader
+    1017385934, // Void Dexterity
+  ],
+  '3555350691': [
+    1501094193, // Strand Weapon Surge
+    2805854721, // Strand Holster
+    1305848463, // Strand Scavenger
+    3279257734, // Strand Siphon
+    3013778406, // Strand Targeting
+    3598972737, // Unflinching Strand Aim
+    2303417969, // Strand Reserves
+    95934356, // Strand Loader
+    3979300428, // Strand Dexterity
+  ],
+  '3555350692': [
+    2831374162, // Solar/Strand Dual Siphon
+    110793779, // Void/Strand Dual Siphon
+  ],
+  '3555350693': [
+    2136310244, // Ashes to Assets
+    965934024, // Firepower
+    2031584061, // Momentum Transfer
+    3245543337, // Bolstering Detonation
+    1924584408, // Grenade Kickstart
+    1153260021, // Impact Induction
+  ],
+};

--- a/output/artifact-mod-unlocks.ts
+++ b/output/artifact-mod-unlocks.ts
@@ -1,0 +1,47 @@
+export const artifactPlugUnlocks: { [artifactModHash: number]: number[] } = {
+  '3555350688': [
+    2283894334, // Solar Weapon Surge
+    3675553168, // Solar Holster
+    56663992, // Solar Scavenger
+    1086997255, // Solar Siphon
+    331268185, // Solar Targeting
+    1019574576, // Unflinching Solar Aim
+    411014648, // Solar Reserves
+    634608391, // Solar Loader
+    531665167, // Solar Dexterity
+  ],
+  '3555350690': [
+    3914973263, // Void Weapon Surge
+    2634786903, // Void Holster
+    2815817957, // Void Scavenger
+    1210012576, // Void Siphon
+    2888195476, // Void Targeting
+    3887037435, // Unflinching Void Aim
+    2413278875, // Void Reserves
+    3224649746, // Void Loader
+    1017385934, // Void Dexterity
+  ],
+  '3555350691': [
+    1501094193, // Strand Weapon Surge
+    2805854721, // Strand Holster
+    1305848463, // Strand Scavenger
+    3279257734, // Strand Siphon
+    3013778406, // Strand Targeting
+    3598972737, // Unflinching Strand Aim
+    2303417969, // Strand Reserves
+    95934356, // Strand Loader
+    3979300428, // Strand Dexterity
+  ],
+  '3555350692': [
+    2831374162, // Solar/Strand Dual Siphon
+    110793779, // Void/Strand Dual Siphon
+  ],
+  '3555350693': [
+    2136310244, // Ashes to Assets
+    965934024, // Firepower
+    2031584061, // Momentum Transfer
+    3245543337, // Bolstering Detonation
+    1924584408, // Grenade Kickstart
+    1153260021, // Impact Induction
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "generate:glyph-enums": "dotenv node built/src/generate-font-glyph-enums.js && tsc",
     "generate:legacy-triumphs": "fse copy --quiet data/legacy-triumphs.json output/legacy-triumphs.json",
     "generate:stat-effects": "fse copy --quiet data/stat-effects.ts output/stat-effects.ts",
+    "generate:artifact-mod-unlocks": "fse copy --quiet data/artifact-mod-unlocks.ts output/artifact-mod-unlocks.ts",
     "generate:trials-objectives": "dotenv node built/src/generate-trials-objectives.js",
     "generate:crafting-enhanced-intrinsics": "dotenv node built/src/generate-crafting-enhanced-intrinsics.js",
     "generate:trait-enhanced-trait": "dotenv node built/src/generate-trait-enhanced-trait-lookup.js",


### PR DESCRIPTION
These were generated by grabbing profile responses after resetting the artifact and re-unlocking the relevant artifact mods one by one. The script that does that is not in a state where it can be committed to this repository, but for posterity I've added it to a separate branch at https://github.com/robojumper/d2-additional-info/commit/95aa9b190fe82d2919eb960bd4e024ea2091c876