### PR TITLE
Auto Manifest - no more pnpm manifest:get

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Compile Typescript
-        run: pnpm build
-
       - name: Generate Data
         run: pnpm generate-data
 

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -37,15 +37,6 @@ jobs:
       - name: Compile Typescript
         run: pnpm build
 
-      - name: Get D2 Manifest
-        uses: nick-fields/retry@v2.9.0
-        with:
-          timeout_minutes: 2
-          max_attempts: 3
-          command: pnpm manifest:get
-        env:
-          API_KEY: ${{ secrets.API_KEY }}
-
       - name: Generate Data
         run: pnpm generate-data
 

--- a/.github/workflows/new-manifest-detected.yml
+++ b/.github/workflows/new-manifest-detected.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Build
-        run: pnpm build
-
       - name: Generate new D2AI information
         run: pnpm generate-data
 

--- a/.github/workflows/new-manifest-detected.yml
+++ b/.github/workflows/new-manifest-detected.yml
@@ -28,15 +28,6 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Update D2AI with new manifest information
-        uses: nick-fields/retry@v2.9.0
-        with:
-          timeout_minutes: 2
-          max_attempts: 3
-          command: pnpm manifest:get
-        env:
-          API_KEY: ${{ secrets.API_KEY }}
-
       - name: Generate new D2AI information
         run: pnpm generate-data
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 ## How to use:
 
 - pnpm install
-- pnpm build
 - pnpm generate-data
 
 ## Debug pre-commit hook

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 - pnpm install
 - pnpm build
-- pnpm manifest:get
 - pnpm generate-data
 
 ## Debug pre-commit hook

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "watch": "tsc --watch --assumeChangesOnlyAffectDirectDependencies --preserveWatchOutput",
     "pretty": "prettier --write \"**/*.{js,ts,tsx,scss,html,json}\"",
     "lint": "eslint --fix src --ext .js,.ts,.tsx",
-    "manifest:get": "dotenv node built/src/getD2Manifest.js",
     "manifest:pretty": "dotenv node built/src/generate-pretty-manifest.js",
     "generate-data-main": "dotenv node built/src/main.js",
     "generate-data-font": "dotenv node built/src/main.js generate-font-glyph-enums generate-symbols",

--- a/src/generate-pretty-manifest.ts
+++ b/src/generate-pretty-manifest.ts
@@ -1,15 +1,16 @@
-import { allManifest, loadLocal } from '@d2api/manifest-node';
+import { allManifest, load } from '@d2api/manifest-node';
 import { makeDirIfMissing, writeFile } from './helpers.js';
 
-loadLocal();
+await load();
 
 const dir = './manifest_tables';
 
-makeDirIfMissing(dir);
+if (allManifest) {
+  makeDirIfMissing(dir);
 
-Object.entries(allManifest!).forEach(function ([table, tableData]) {
-  const shortName = table.match(/^Destiny(\w+)Definition$/)![1];
-  writeFile(`${dir}/${shortName}.json`, tableData);
-});
+  Object.entries(allManifest).forEach(function ([table, tableData]) {
+    writeFile(`${dir}/${table}.json`, tableData);
+  });
 
-writeFile(`${dir}/all.json`, allManifest!);
+  writeFile(`${dir}/all.json`, allManifest);
+}

--- a/src/getD2Manifest.ts
+++ b/src/getD2Manifest.ts
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-
-import { load, setApiKey } from '@d2api/manifest-node';
-
-setApiKey(process.env.API_KEY);
-load();

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { registerWriteHook } from './helpers.js';
 const { copyFileSync } = fse;
 
 setApiKey(process.env.API_KEY);
-load();
+await load();
 
 const scriptRegex = /generate-([a-zA-Z\\-]+)\.ts/;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,6 +68,7 @@ tsFiles.sort((fileA, fileB) => {
 });
 
 let totalTscRuntime = 0;
+let totalJsRunTime = 0;
 
 registerWriteHook((fileName) => {
   if (
@@ -97,7 +98,8 @@ for (const tsFile of tsFiles) {
   // has the side effect of running their contents.
   await import('./' + jsFile);
   const [s, ns] = process.hrtime(t);
-  runtime[tsFile] = s + ns / 1e9;
+  runtime[jsFile] = s + ns / 1e9;
+  totalJsRunTime += runtime[jsFile];
 }
 
 for (const toCopyFile of copyDataToOutput) {
@@ -107,3 +109,4 @@ for (const toCopyFile of copyDataToOutput) {
 const runtimes = Object.entries(runtime).sort((a, b) => b[1] - a[1]);
 console.table(runtimes);
 console.log('total tsc runtime', totalTscRuntime);
+console.log('total js runtime', totalJsRunTime);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { loadLocal } from '@d2api/manifest-node';
+import { load, setApiKey } from '@d2api/manifest-node';
 import { spawnSync } from 'child_process';
 import { readdirSync } from 'fs';
 import fse from 'fs-extra';
@@ -8,7 +8,8 @@ import { registerWriteHook } from './helpers.js';
 
 const { copyFileSync } = fse;
 
-loadLocal();
+setApiKey(process.env.API_KEY);
+load();
 
 const scriptRegex = /generate-([a-zA-Z\\-]+)\.ts/;
 


### PR DESCRIPTION
remove the need to manually update the manifest
small cleanups added:
generate-data already runs build... no need to run it twice
add jsTotalTime to output as well