### PR TITLE
Categorize Whisper and Zero Hour under ITL. Add "Brave" category.

### DIFF
--- a/data/sources/categories.json
+++ b/data/sources/categories.json
@@ -28,7 +28,8 @@
       "alias": ["ada"]
     },
     "brave": {
-      "includes": ["Into the Light"]
+      "includes": ["Into the Light"],
+      "items": ["3098328572","4043921923","2480074702","3757612024","2499720827","243425374","211732170","205225492","2533990645","3851176026","570866107","568611923"]
     },
     "calus": {
       "includes": ["leviathan", "menagerie", "crown of sorrow"],
@@ -544,6 +545,7 @@
     },
     "intothelight": {
       "includes": ["Into the Light", "Exotic Mission \"The Whisper\"", "Exotic Mission \"Zero Hour\""],
+      "items": ["3098328572","4043921923","2480074702","3757612024","2499720827","243425374","211732170","205225492","2533990645","3851176026","570866107","568611923"],
       "alias": ["itl"]
     },
     "wellspring": {

--- a/data/sources/categories.json
+++ b/data/sources/categories.json
@@ -27,6 +27,9 @@
       ],
       "alias": ["ada"]
     },
+    "brave": {
+      "includes": ["Into the Light"]
+    },
     "calus": {
       "includes": ["leviathan", "menagerie", "crown of sorrow"],
       "excludes": ["chalice"],
@@ -540,7 +543,8 @@
       "includes": ["Eternity", "Grasp of Avarice", "Magnum Opus", "And Out Fly the Wolves"]
     },
     "intothelight": {
-      "includes": ["Into the Light"]
+      "includes": ["Into the Light", "Exotic Mission \"The Whisper\""],
+      "alias": ["itl"]
     },
     "wellspring": {
       "includes": ["Wellspring", "All the Spring's Riches", "Warden of the Spring"]

--- a/data/sources/categories.json
+++ b/data/sources/categories.json
@@ -543,7 +543,7 @@
       "includes": ["Eternity", "Grasp of Avarice", "Magnum Opus", "And Out Fly the Wolves"]
     },
     "intothelight": {
-      "includes": ["Into the Light", "Exotic Mission \"The Whisper\""],
+      "includes": ["Into the Light", "Exotic Mission \"The Whisper\"", "Exotic Mission \"Zero Hour\""],
       "alias": ["itl"]
     },
     "wellspring": {

--- a/data/sources/unassigned.json
+++ b/data/sources/unassigned.json
@@ -5,7 +5,6 @@
   "1664308183": "Source: Season of the Wish Activities",
   "1751739544": "Source: \"We Stand Unbroken\" Quest, Week 5",
   "1902517582": "Source: Where's Archie?",
-  "2068312112": "Source: Exotic Mission \"Zero Hour\"",
   "2585665369": "A foreboding staff bearing engravings of Hive runes and bound with mystical charms.",
   "2671038131": "",
   "2959452483": "",

--- a/data/sources/unassigned.json
+++ b/data/sources/unassigned.json
@@ -2,7 +2,6 @@
   "561126969": "Source: \"Starcrossed\" Mission",
   "1035822060": "",
   "1085506849": "Source: \"We Stand Unbroken\" Quest, Week 8",
-  "1388323447": "Source: Exotic Mission \"The Whisper\"",
   "1664308183": "Source: Season of the Wish Activities",
   "1751739544": "Source: \"We Stand Unbroken\" Quest, Week 5",
   "1902517582": "Source: Where's Archie?",

--- a/output/missing-source-info.ts
+++ b/output/missing-source-info.ts
@@ -42,6 +42,15 @@ const missingSources: { [key: string]: number[] } = {
   blackarmory: [
     2533990645, // Blast Furnace
   ],
+  brave: [
+    211732170, // Hammerhead
+    243425374, // Falling Guillotine
+    570866107, // Succession
+    2228325504, // Edge Transit
+    2499720827, // Midnight Coup
+    3757612024, // Luna's Howl
+    3851176026, // Elsie's Rifle
+  ],
   calus: [
     17280095, // Shadow's Strides
     30962015, // Boots of the Ace-Defiant
@@ -1964,6 +1973,15 @@ const missingSources: { [key: string]: number[] } = {
     4196689510, // Iron Fellowship Robes
     4211068696, // Iron Truage Legs
     4248834293, // Iron Remembrance Vest
+  ],
+  itl: [
+    211732170, // Hammerhead
+    243425374, // Falling Guillotine
+    570866107, // Succession
+    2228325504, // Edge Transit
+    2499720827, // Midnight Coup
+    3757612024, // Luna's Howl
+    3851176026, // Elsie's Rifle
   ],
   kf: [
     3414225760, // Touch of Malice

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -137,6 +137,13 @@ const D2Sources: {
     ],
     searchString: [],
   },
+  brave: {
+    itemHashes: [],
+    sourceHashes: [
+      2952071500, // Source: Into the Light
+    ],
+    searchString: [],
+  },
   calus: {
     itemHashes: [
       1661191192, // The Tribute Hall
@@ -783,6 +790,7 @@ const D2Sources: {
   intothelight: {
     itemHashes: [],
     sourceHashes: [
+      1388323447, // Source: Exotic Mission "The Whisper"
       2952071500, // Source: Into the Light
     ],
     searchString: [],
@@ -819,6 +827,14 @@ const D2Sources: {
       2648408612, // Acquired by competing in the Iron Banner when the wolves were loud.
       3072862693, // Source: Complete Iron Banner matches and earn rank-up packages from Lord Saladin.
       3966667255, // Source: Iron Banner's Season 9 Seasonal Quest
+    ],
+    searchString: [],
+  },
+  itl: {
+    itemHashes: [],
+    sourceHashes: [
+      1388323447, // Source: Exotic Mission "The Whisper"
+      2952071500, // Source: Into the Light
     ],
     searchString: [],
   },

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -791,6 +791,7 @@ const D2Sources: {
     itemHashes: [],
     sourceHashes: [
       1388323447, // Source: Exotic Mission "The Whisper"
+      2068312112, // Source: Exotic Mission "Zero Hour"
       2952071500, // Source: Into the Light
     ],
     searchString: [],
@@ -834,6 +835,7 @@ const D2Sources: {
     itemHashes: [],
     sourceHashes: [
       1388323447, // Source: Exotic Mission "The Whisper"
+      2068312112, // Source: Exotic Mission "Zero Hour"
       2952071500, // Source: Into the Light
     ],
     searchString: [],

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -138,7 +138,20 @@ const D2Sources: {
     searchString: [],
   },
   brave: {
-    itemHashes: [],
+    itemHashes: [
+      205225492, // Hung Jury SR4
+      211732170, // Hammerhead
+      243425374, // Falling Guillotine
+      568611923, // Edge Transit
+      570866107, // Succession
+      2480074702, // Forbearance
+      2499720827, // Midnight Coup
+      2533990645, // Blast Furnace
+      3098328572, // The Recluse
+      3757612024, // Luna's Howl
+      3851176026, // Elsie's Rifle
+      4043921923, // The Mountaintop
+    ],
     sourceHashes: [
       2952071500, // Source: Into the Light
     ],
@@ -788,7 +801,20 @@ const D2Sources: {
     searchString: [],
   },
   intothelight: {
-    itemHashes: [],
+    itemHashes: [
+      205225492, // Hung Jury SR4
+      211732170, // Hammerhead
+      243425374, // Falling Guillotine
+      568611923, // Edge Transit
+      570866107, // Succession
+      2480074702, // Forbearance
+      2499720827, // Midnight Coup
+      2533990645, // Blast Furnace
+      3098328572, // The Recluse
+      3757612024, // Luna's Howl
+      3851176026, // Elsie's Rifle
+      4043921923, // The Mountaintop
+    ],
     sourceHashes: [
       1388323447, // Source: Exotic Mission "The Whisper"
       2068312112, // Source: Exotic Mission "Zero Hour"
@@ -832,7 +858,20 @@ const D2Sources: {
     searchString: [],
   },
   itl: {
-    itemHashes: [],
+    itemHashes: [
+      205225492, // Hung Jury SR4
+      211732170, // Hammerhead
+      243425374, // Falling Guillotine
+      568611923, // Edge Transit
+      570866107, // Succession
+      2480074702, // Forbearance
+      2499720827, // Midnight Coup
+      2533990645, // Blast Furnace
+      3098328572, // The Recluse
+      3757612024, // Luna's Howl
+      3851176026, // Elsie's Rifle
+      4043921923, // The Mountaintop
+    ],
     sourceHashes: [
       1388323447, // Source: Exotic Mission "The Whisper"
       2068312112, // Source: Exotic Mission "Zero Hour"


### PR DESCRIPTION
(Rebased on https://github.com/DestinyItemManager/d2-additional-info/pull/579)

* Adds Whisper and Zero Hour to `intothelight` category
* Adds `itl` as alias for `intothelight`
* Adds separate category `brave` which contains only BRAVE weapons/armor, not Whisper/Zero Hour