### PR TITLE
Clean up source info for season pass

### DIFF
--- a/data/sources/categories.json
+++ b/data/sources/categories.json
@@ -262,7 +262,7 @@
       "alias": ["scourge", "sotp"]
     },
     "seasonpass": {
-      "includes": ["season pass", "Source: Season of"],
+      "includes": ["season pass", "Source: Season of", "Season Pass Reward"],
       "excludes": [
         "dungeon",
         "nightfall",
@@ -277,18 +277,6 @@
         "the Chosen",
         "the Worthy",
         "the Lost"
-      ],
-      "items": [
-        "Firefright",
-        "Without Remorse",
-        "Brass Attacks",
-        "Threaded Needle",
-        "Sojourner's Tale",
-        "Shattered Cipher",
-        "Thoughtless",
-        "Piece of Mind",
-        "Brigand's Law",
-        "Planck's Stride"
       ]
     },
     "shipwright": { "includes": ["Amanda Holliday"] },

--- a/output/source-info-v2.ts
+++ b/output/source-info-v2.ts
@@ -991,18 +991,6 @@ const D2Sources: {
     aliases: ['scourge', 'sotp'],
   },
   seasonpass: {
-    itemHashes: [
-      599895591, // Sojourner's Tale
-      820890091, // Planck's Stride
-      1298815317, // Brigand's Law
-      1478986057, // Without Remorse
-      2097055732, // Piece of Mind
-      2121785039, // Brass Attacks
-      2434225986, // Shattered Cipher
-      2778013407, // Firefright
-      3075224551, // Threaded Needle
-      4067556514, // Thoughtless
-    ],
     sourceHashes: [
       450719423, // Source: Season of the Risen
       794422188, // Source: Season of the Witch

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -1347,18 +1347,7 @@ const D2Sources: {
     searchString: [],
   },
   seasonpass: {
-    itemHashes: [
-      599895591, // Sojourner's Tale
-      820890091, // Planck's Stride
-      1298815317, // Brigand's Law
-      1478986057, // Without Remorse
-      2097055732, // Piece of Mind
-      2121785039, // Brass Attacks
-      2434225986, // Shattered Cipher
-      2778013407, // Firefright
-      3075224551, // Threaded Needle
-      4067556514, // Thoughtless
-    ],
+    itemHashes: [],
     sourceHashes: [
       450719423, // Source: Season of the Risen
       794422188, // Source: Season of the Witch


### PR DESCRIPTION
I noticed that these items could be found through the "Source: Season Pass Reward" source string.