### PR TITLE
Add Vesper's Host items to Dungeon category

### DIFF
--- a/data/sources/category-config.ts
+++ b/data/sources/category-config.ts
@@ -338,6 +338,14 @@ export const matchTable: {
     extends: ['dungeon'],
     originTrait: ['Sundering'],
   },
+  {
+    // ADDED IN SEASON 25 AKA EPISODE 2
+    sourceName: 'vespershost',
+    desc: ["Vesper's Host"],
+    alias: ['vesper'],
+    extends: ['dungeon'],
+    originTrait: ['Bray Legacy'],
+  },
   // ==========================================================================
   //                                EXOTIC QUESTS
   // ==========================================================================

--- a/output/missing-source-info.ts
+++ b/output/missing-source-info.ts
@@ -3106,6 +3106,40 @@ const missingSources: { [key: string]: number[] } = {
     4177448932, // Focusing Wraps
     4248997900, // Incisor
   ],
+  vesper: [
+    239405325, // Spacewalk Strides
+    480133716, // Spacewalk Robes
+    498496285, // Spacewalk Cover
+    898451378, // Spacewalk Cowl
+    1265540521, // Spacewalk Bond
+    1364804507, // Spacewalk Grasps
+    2147583688, // Spacewalk Cloak
+    2155757770, // Spacewalk Mark
+    2867324653, // Spacewalk Gauntlets
+    3067211509, // Spacewalk Vest
+    3113666223, // Spacewalk Greaves
+    3255995532, // Spacewalk Gloves
+    3820841619, // Spacewalk Plate
+    3901727798, // Spacewalk Boots
+    4036496212, // Spacewalk Helm
+  ],
+  vespershost: [
+    239405325, // Spacewalk Strides
+    480133716, // Spacewalk Robes
+    498496285, // Spacewalk Cover
+    898451378, // Spacewalk Cowl
+    1265540521, // Spacewalk Bond
+    1364804507, // Spacewalk Grasps
+    2147583688, // Spacewalk Cloak
+    2155757770, // Spacewalk Mark
+    2867324653, // Spacewalk Gauntlets
+    3067211509, // Spacewalk Vest
+    3113666223, // Spacewalk Greaves
+    3255995532, // Spacewalk Gloves
+    3820841619, // Spacewalk Plate
+    3901727798, // Spacewalk Boots
+    4036496212, // Spacewalk Helm
+  ],
   votd: [
     2480074702, // Forbearance
   ],

--- a/output/source-info-v2.ts
+++ b/output/source-info-v2.ts
@@ -366,6 +366,7 @@ const D2Sources: {
       1282207663, // Source: Dungeon "Duality"
       1597738585, // Source: "Spire of the Watcher" Dungeon
       1745960977, // Source: "Pit of Heresy" Dungeon
+      2463956052, // Source: Vesper's Host
       3288974535, // Source: "Ghosts of the Deep" Dungeon
     ],
     itemHashes: [
@@ -1383,6 +1384,12 @@ const D2Sources: {
       2065138144, // Source: "Vault of Glass" Raid
     ],
     aliases: ['vog'],
+  },
+  vespershost: {
+    sourceHashes: [
+      2463956052, // Source: Vesper's Host
+    ],
+    aliases: ['vesper'],
   },
   vexoffensive: {
     itemHashes: [

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -742,6 +742,7 @@ const D2Sources: {
       1282207663, // Source: Dungeon "Duality"
       1597738585, // Source: "Spire of the Watcher" Dungeon
       1745960977, // Source: "Pit of Heresy" Dungeon
+      2463956052, // Source: Vesper's Host
       3288974535, // Source: "Ghosts of the Deep" Dungeon
     ],
     searchString: [],
@@ -2065,6 +2066,20 @@ const D2Sources: {
     itemHashes: [],
     sourceHashes: [
       2065138144, // Source: "Vault of Glass" Raid
+    ],
+    searchString: [],
+  },
+  vesper: {
+    itemHashes: [],
+    sourceHashes: [
+      2463956052, // Source: Vesper's Host
+    ],
+    searchString: [],
+  },
+  vespershost: {
+    itemHashes: [],
+    sourceHashes: [
+      2463956052, // Source: Vesper's Host
     ],
     searchString: [],
   },


### PR DESCRIPTION
Adds Vesper's Host as a distinct dungeon in the schema. Adds `source:vespershost` and `source:vesper`, plus ensures Vesper's Host items match `source:dungeon`.

Documentation is a little fuzzy on this part of DIM so let me know if I missed something.