### PR TITLE
add some leeway in case d2ai runs right before reset

### DIFF
--- a/src/generate-season-info.ts
+++ b/src/generate-season-info.ts
@@ -373,6 +373,7 @@ function getEndDate(seasonNumber: number) {
 
 function getCurrentSeasonPass(currentDate = new Date()) {
   const { seasonPassList } = seasonDefs[D2CalculatedSeason];
+  currentDate.setHours(currentDate.getHours() + 5); // Add 5 hours to the current hour, in case the definitions drop too early
   const currentTimeUTC = currentDate.getTime();
 
   for (let i = 0; i < seasonPassList.length; i++) {


### PR DESCRIPTION
d2ai can run up to 5 hours before reset and still think we are after reset, in case the definitions get released before reset