### PR TITLE
Add Desert Perpetual, handle oversight for Nightmare Hunt/Root of Nightmares

### DIFF
--- a/data/sources/category-config.ts
+++ b/data/sources/category-config.ts
@@ -284,7 +284,7 @@ export const matchTable: {
   {
     // ADDED IN YEAR 8 (EDGE OF FATE)
     sourceName: 'desertperpetual',
-    desc: ["Desert Perpetual"],
+    desc: ['Desert Perpetual'],
     alias: ['dp', 'desert'],
     extends: ['raid'],
   },

--- a/data/sources/category-config.ts
+++ b/data/sources/category-config.ts
@@ -281,6 +281,13 @@ export const matchTable: {
     desc: ["Salvation's Edge"],
     extends: ['raid'],
   },
+  {
+    // ADDED IN YEAR 8 (EDGE OF FATE)
+    sourceName: 'desertperpetual',
+    desc: ["Desert Perpetual"],
+    alias: ['dp', 'desert'],
+    extends: ['raid'],
+  },
   // ==========================================================================
   //                                    DUNGEONS
   // ==========================================================================
@@ -867,6 +874,7 @@ export const matchTable: {
   {
     sourceName: 'nightmare',
     desc: ['nightmare'],
+    excludes: ['Root of Nightmares'],
   },
   {
     sourceName: 'prestige',

--- a/output/source-info-v2.ts
+++ b/output/source-info-v2.ts
@@ -350,6 +350,12 @@ const D2Sources: {
     ],
     aliases: ['limited'],
   },
+  desertperpetual: {
+    sourceHashes: [
+      596084342, // Source: "The Desert Perpetual" Raid
+    ],
+    aliases: ['dp', 'desert'],
+  },
   do: {
     sourceHashes: [
       146504277, // Source: Earn rank-up packages from Arach Jalaal.
@@ -1019,7 +1025,6 @@ const D2Sources: {
     sourceHashes: [
       550270332, // Source: Complete all Nightmare Hunt time trials on Master difficulty.
       2778435282, // Source: Nightmare Hunts
-      3190710249, // Source: "Root of Nightmares" Raid
     ],
   },
   nm: {

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -669,10 +669,31 @@ const D2Sources: {
     ],
     searchString: [],
   },
+  desert: {
+    itemHashes: [],
+    sourceHashes: [
+      596084342, // Source: "The Desert Perpetual" Raid
+    ],
+    searchString: [],
+  },
+  desertperpetual: {
+    itemHashes: [],
+    sourceHashes: [
+      596084342, // Source: "The Desert Perpetual" Raid
+    ],
+    searchString: [],
+  },
   do: {
     itemHashes: [],
     sourceHashes: [
       146504277, // Source: Earn rank-up packages from Arach Jalaal.
+    ],
+    searchString: [],
+  },
+  dp: {
+    itemHashes: [],
+    sourceHashes: [
+      596084342, // Source: "The Desert Perpetual" Raid
     ],
     searchString: [],
   },
@@ -1549,7 +1570,6 @@ const D2Sources: {
     sourceHashes: [
       550270332, // Source: Complete all Nightmare Hunt time trials on Master difficulty.
       2778435282, // Source: Nightmare Hunts
-      3190710249, // Source: "Root of Nightmares" Raid
     ],
     searchString: [],
   },


### PR DESCRIPTION
All of the items have "Desert Perpetual" in the source text this time.