### PR TITLE
Add `source:kepler`

### DIFF
--- a/data/sources/category-config.ts
+++ b/data/sources/category-config.ts
@@ -155,9 +155,9 @@ export const matchTable: {
   },
   {
     // ADDED IN SEASON 27
-    sourceName: 'edgeoffate',
+    sourceName: 'kepler',
     desc: ['Kepler'],
-    originTrait: [],
+    originTrait: ["Exhaustive Research"],
   },
   // ==========================================================================
   //                                   RAIDS

--- a/output/source-info-v2.ts
+++ b/output/source-info-v2.ts
@@ -791,6 +791,11 @@ const D2Sources: {
       3072862693, // Source: Complete Iron Banner matches and earn rank-up packages from Lord Saladin.
     ],
   },
+  kepler: {
+    sourceHashes: [
+      4284811963, // Source: Exploring Kepler
+    ],
+  },
   kingsfall: {
     sourceHashes: [
       160129377, // Source: "King's Fall" Raid

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -1266,6 +1266,13 @@ const D2Sources: {
     ],
     searchString: [],
   },
+  kepler: {
+    itemHashes: [],
+    sourceHashes: [
+      4284811963, // Source: Exploring Kepler
+    ],
+    searchString: [],
+  },
   kf: {
     itemHashes: [],
     sourceHashes: [


### PR DESCRIPTION
Adding a `source:kepler` in line with the other destination-based sources like `paleheart` or `throneworld`

This does not appear to impact the existing `edgeoffate` source, which is also defined under the "EPISODES" section of category-config.ts.