### PR TITLE
Harden and modernize GitHub Actions workflows

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -12,13 +12,13 @@ runs:
   steps:
     - name: Checkout
       if: inputs.checkout == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version-file: '.nvmrc'
         cache: pnpm

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,19 +1,8 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ['master']
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -22,8 +11,7 @@ on:
       - 'CHANGELOG.md'
       - 'LICENSE'
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: ['master']
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -33,6 +21,10 @@ on:
       - 'LICENSE'
   schedule:
     - cron: '35 8 * * 0'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
@@ -47,43 +39,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: ['javascript-typescript']
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended,security-and-quality
 
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,16 +1,18 @@
 name: Dependabot auto-merge
 on: pull_request_target
 
+# The merge is performed with the GitHub App token created below, so the
+# default GITHUB_TOKEN only needs read access.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           # required
@@ -18,7 +20,7 @@ jobs:
           private-key: ${{ secrets.AUTOMERGE_PRIVATE_KEY }}
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: '${{ steps.app-token.outputs.token }}'
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/new-manifest-detected.yml
+++ b/.github/workflows/new-manifest-detected.yml
@@ -5,15 +5,25 @@ on:
   repository_dispatch:
     types: [new-manifest-detected]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup
         uses: ./.github/actions/setup-pnpm
+        with:
+          checkout: 'false'
 
       - name: Generate new D2AI information
         env:
@@ -21,7 +31,7 @@ jobs:
         run: pnpm generate-data
 
       - name: porcelain check
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: D2AI-data
         with:
           base: HEAD
@@ -31,7 +41,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.D2AI-data.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.PAT }}
           commit-message: D2AI - Update All - Manifest v${{ github.event.client_payload.config.env.MANIFEST_VERSION }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,6 +6,9 @@ on:
     paths:
       ['src/**', 'data/**', '.github/workflows/pr-validation.yml', 'package.json', 'pnpm-lock.yaml']
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,18 +20,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: pnpm/action-setup@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
+      - name: Setup
+        uses: ./.github/actions/setup-pnpm
         with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile --prefer-offline
+          checkout: 'false'
 
       - name: Check formatting
         run: pnpm format:check
@@ -37,7 +34,7 @@ jobs:
         run: pnpm exec oxlint src --type-aware --format=github
 
       - name: Cache TypeScript build
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             built
@@ -52,7 +49,7 @@ jobs:
         run: pnpm generate-data
 
       - name: Check for changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: data
         with:
           base: HEAD
@@ -62,7 +59,7 @@ jobs:
 
       - name: Fail if data not generated
         if: steps.data.outputs.changed == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.setFailed('Generated data is out of date. Please run `pnpm generate-data` and commit the changes.')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
     branches: ['master']
     paths: ['output/**']
 
+permissions:
+  contents: read
+
 # Ensures that only one deploy task per branch/environment will run at a time.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,14 +18,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout - D2AI
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: 'd2ai'
           fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout - DIM
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: DestinyItemManager/DIM
           path: 'DIM'
@@ -34,7 +37,7 @@ jobs:
         run: find src/data/d2/* -delete && cp -f ../d2ai/output/* ./src/data/d2/
 
       - name: Create Pull Request (DIM)
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           path: 'DIM'
           token: ${{ secrets.PAT }}
@@ -56,14 +59,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout - D2AI
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: 'd2ai'
           fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout - D2AI-module
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: DestinyItemManager/d2ai-module
           path: 'd2ai-module'

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -7,16 +7,20 @@ on:
     branches: [master]
     paths: ['.github/workflows/**']
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
         with:
           reporter: github-pr-review
           fail_level: error


### PR DESCRIPTION
## Summary

Closes the remaining gaps in the CI/CD workflows: missing least-privilege permissions, a pnpm-version drift, an unhardened manifest workflow, stale CodeQL boilerplate, and unpinned third-party actions that touch secrets/PRs.

## Changes

**Least-privilege permissions** — added explicit top-level `permissions:` to every workflow that lacked one:
- `pr-validation`, `publish`, `new-manifest-detected` → `contents: read` (cross-repo writes use `secrets.PAT`)
- `workflow-lint` → `contents: read` + `pull-requests: write` (reviewdog PR reporter)
- `dependabot-automerge` → default token tightened from `write` to `contents: read` (merge uses the app token)

**Removed pnpm drift + duplication**
- Composite `setup-pnpm` bumped `pnpm/action-setup@v4` → `v6`
- `pr-validation` now reuses the `setup-pnpm` composite instead of duplicating 4 setup steps; both callers pass `checkout: 'false'` and check out first, removing the redundant double-checkout in `new-manifest-detected`

**Hardened workflows**
- `new-manifest-detected`: added `permissions`, `timeout-minutes: 15`, `concurrency` group
- `dependabot-automerge`: added `timeout-minutes: 5`

**Modernized CodeQL**
- `javascript` → `javascript-typescript`, dropped `Autobuild` for `build-mode: none`
- Enabled `security-extended,security-and-quality` queries
- Added `concurrency` group, stripped template boilerplate

**SHA-pinned all actions** (first- and third-party) with `# vN` comments. Dependabot's `github-actions` group keeps the SHAs updated.

## Verification
- All workflow YAML parses cleanly
- `actionlint` runs on this PR via `workflow-lint.yml`
- `pr-validation` exercises the refactored `setup-pnpm` composite end-to-end