### PR TITLE
Add charity source matched by iconWatermark

### DIFF
--- a/data/sources/category-config.ts
+++ b/data/sources/category-config.ts
@@ -44,6 +44,12 @@ export const matchTable: {
    */
   equipableItemSetHashes?: number[];
   /**
+   * iconWatermark filename(s) (or substrings) that belong to this sourceTag.
+   * Any item whose iconWatermark contains one of these is included. Useful for
+   * sources that share a distinctive watermark but no usable sourceString.
+   */
+  iconWatermark?: string[];
+  /**
    * the season this source was relagated into the DCV
    */
   enteredDCV?: number;
@@ -1167,13 +1173,17 @@ export const matchTable: {
       'Limited Edition',
       'special offer',
       'Deluxe Edition',
-      'charity',
       'pre-order bonus',
       'preorder',
       'Refer-a-Friend',
       'Handed out',
     ],
     alias: ['limited'],
+  },
+  {
+    sourceName: 'charity',
+    desc: ['charity'],
+    iconWatermark: ['2b89827888c5581a14af976968bcb18a.png'],
   },
   {
     sourceName: 'campaign',

--- a/output/source-info-v2.ts
+++ b/output/source-info-v2.ts
@@ -210,6 +210,53 @@ const D2Sources: {
     ],
     enteredDCV: 20,
   },
+  charity: {
+    itemHashes: [
+      40494562, // Caped Cruiser
+      171635528, // Hearts of Gold
+      171635529, // Principled Porphyry
+      171635530, // Argent Champion
+      371705660, // Unconditional Love
+      765122182, // Tenderhearted Shell
+      826128643, // Small Luminance
+      902219633, // Bridge of Magpies
+      1047542010, // On Your Sleeve
+      1047542011, // Heart Felt
+      1059396448, // Tenth Muse
+      1059396449, // Boundless
+      1059396450, // Steadfast Column
+      1059396451, // True Self
+      1059396454, // Indivisible
+      1061507881, // Altair Runner
+      1165452712, // Cosmic Tune
+      1257250409, // Seventh Sail
+      1283654212, // Gilded Shell
+      2068483326, // Phosphor Gladiator
+      2268540161, // Warm Munificence
+      2609270227, // Arena Shell
+      2635366068, // Buoyant Shell
+      2650448800, // Love Note Shell
+      2650448801, // Heart's Oath Shell
+      2704911691, // Lovestruck
+      2749628923, // Disciple's Shell
+      2764545753, // Empathic Shell
+      2778157412, // Sweetheart Shell
+      2811138603, // Altrux Pura Mk1
+      3154194046, // Kilted Out
+      3159276286, // Cosmic Arcade
+      3229426560, // Laser Tag Brag
+      3596008431, // Pale Blue Dot
+      3919847952, // Circadian Guard
+      4163975820, // Lubraean Luxury
+      4182403848, // Prismatic Expanse
+      4201060647, // Offset
+      4222561358, // Light Hearted
+      4253857367, // Heartful Shell
+    ],
+    sourceHashes: [
+      2985242208, // Source: Earned from a charity promotion.
+    ],
+  },
   compass: {
     sourceHashes: [
       164083100, // Source: Display of Supremacy, Weekly Challenge
@@ -445,7 +492,6 @@ const D2Sources: {
       1743434737, // Source: Destiny 2 "Forsaken" preorder bonus gift.
       1866448829, // Source: Deluxe Edition Bonus
       2968206374, // Source: Earned as a Deluxe Edition bonus.
-      2985242208, // Source: Earned from a charity promotion.
       3173463761, // Source: Pre-order Bonus
       3212282221, // Source: Forsaken Annual Pass
       3672287903, // Source: The Witch Queen Digital Deluxe Edition

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -260,6 +260,54 @@ const D2Sources: {
     ],
     searchString: [],
   },
+  charity: {
+    itemHashes: [
+      40494562, // Caped Cruiser
+      171635528, // Hearts of Gold
+      171635529, // Principled Porphyry
+      171635530, // Argent Champion
+      371705660, // Unconditional Love
+      765122182, // Tenderhearted Shell
+      826128643, // Small Luminance
+      902219633, // Bridge of Magpies
+      1047542010, // On Your Sleeve
+      1047542011, // Heart Felt
+      1059396448, // Tenth Muse
+      1059396449, // Boundless
+      1059396450, // Steadfast Column
+      1059396451, // True Self
+      1059396454, // Indivisible
+      1061507881, // Altair Runner
+      1165452712, // Cosmic Tune
+      1257250409, // Seventh Sail
+      1283654212, // Gilded Shell
+      2068483326, // Phosphor Gladiator
+      2268540161, // Warm Munificence
+      2609270227, // Arena Shell
+      2635366068, // Buoyant Shell
+      2650448800, // Love Note Shell
+      2650448801, // Heart's Oath Shell
+      2704911691, // Lovestruck
+      2749628923, // Disciple's Shell
+      2764545753, // Empathic Shell
+      2778157412, // Sweetheart Shell
+      2811138603, // Altrux Pura Mk1
+      3154194046, // Kilted Out
+      3159276286, // Cosmic Arcade
+      3229426560, // Laser Tag Brag
+      3596008431, // Pale Blue Dot
+      3919847952, // Circadian Guard
+      4163975820, // Lubraean Luxury
+      4182403848, // Prismatic Expanse
+      4201060647, // Offset
+      4222561358, // Light Hearted
+      4253857367, // Heartful Shell
+    ],
+    sourceHashes: [
+      2985242208, // Source: Earned from a charity promotion.
+    ],
+    searchString: [],
+  },
   coil: {
     itemHashes: [],
     sourceHashes: [
@@ -772,7 +820,6 @@ const D2Sources: {
       1743434737, // Source: Destiny 2 "Forsaken" preorder bonus gift.
       1866448829, // Source: Deluxe Edition Bonus
       2968206374, // Source: Earned as a Deluxe Edition bonus.
-      2985242208, // Source: Earned from a charity promotion.
       3173463761, // Source: Pre-order Bonus
       3212282221, // Source: Forsaken Annual Pass
       3672287903, // Source: The Witch Queen Digital Deluxe Edition
@@ -1590,7 +1637,6 @@ const D2Sources: {
       1743434737, // Source: Destiny 2 "Forsaken" preorder bonus gift.
       1866448829, // Source: Deluxe Edition Bonus
       2968206374, // Source: Earned as a Deluxe Edition bonus.
-      2985242208, // Source: Earned from a charity promotion.
       3173463761, // Source: Pre-order Bonus
       3212282221, // Source: Forsaken Annual Pass
       3672287903, // Source: The Witch Queen Digital Deluxe Edition

--- a/src/generate-source-info.ts
+++ b/src/generate-source-info.ts
@@ -236,6 +236,20 @@ for (const [, matchRule] of Object.entries(matchTable)) {
     itemHashes.push(...dumpedSetItems);
   }
 
+  // include any items whose iconWatermark matches this sourceTag. Some sources
+  // share a distinctive watermark but carry no usable sourceString.
+  if (matchRule.iconWatermark) {
+    const watermarkItems = allInventoryItems
+      .filter(
+        (i) =>
+          !categoryDenyList.some((hash) => i.itemCategoryHashes?.includes(hash)) &&
+          categoryIncludeList.some((hash) => i.itemCategoryHashes?.includes(hash)) &&
+          matchRule.iconWatermark?.some((watermark) => i.iconWatermark?.includes(watermark)),
+      )
+      .map((i) => i.hash);
+    itemHashes.push(...watermarkItems);
+  }
+
   // sort and uniq this after adding all elements
   itemHashes = uniqAndSortArray(itemHashes);
 


### PR DESCRIPTION
Introduces an iconWatermark match rule and a new "charity" source that collects items sharing the charity-promotion watermark (2b89827888c5581a14af976968bcb18a.png). Moves the "charity" sourceString term out of "deluxe" and onto the new source as well.