### PR TITLE
Exclude Eighty-Six from source:vespershost

### DIFF
--- a/data/sources/category-config.ts
+++ b/data/sources/category-config.ts
@@ -435,6 +435,10 @@ export const matchTable: {
     alias: ['vesper'],
     extends: ['dungeon'],
     originTrait: ['Bray Legacy'],
+    // Eighty-Six reuses the "Bray Legacy" origin trait but isn't a Vesper's Host
+    // weapon; it was dumped into the "Random Perks" grab-bag (sourceHash
+    // 2387628034), so the inline origin-trait reclaim would otherwise mis-assign it.
+    excludedItems: ['Eighty-Six'],
   },
   {
     // ADDED IN SEASON 26 AKA EPISODE 3

--- a/output/source-info-v2.ts
+++ b/output/source-info-v2.ts
@@ -581,7 +581,6 @@ const D2Sources: {
       2129814338, // Prosecutor
       2130249527, // Death Adder
       2226158470, // Unworthy
-      2344383760, // Eighty-Six
       2477408004, // Wilderflight (Adept)
       2485881870, // Unloved
       2730671571, // Terminus Horizon
@@ -2055,7 +2054,6 @@ const D2Sources: {
       93061497, // VS Gravitic Arrest
       1762785662, // VS Chill Inhibitor
       1762785663, // VS Velocity Baton
-      2344383760, // Eighty-Six
       4232480042, // VS Pyroelectric Propellant
     ],
     sourceHashes: [

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -967,7 +967,6 @@ const D2Sources: {
       2129814338, // Prosecutor
       2130249527, // Death Adder
       2226158470, // Unworthy
-      2344383760, // Eighty-Six
       2477408004, // Wilderflight (Adept)
       2485881870, // Unloved
       2730671571, // Terminus Horizon
@@ -2963,7 +2962,6 @@ const D2Sources: {
       93061497, // VS Gravitic Arrest
       1762785662, // VS Chill Inhibitor
       1762785663, // VS Velocity Baton
-      2344383760, // Eighty-Six
       4232480042, // VS Pyroelectric Propellant
     ],
     sourceHashes: [
@@ -2976,7 +2974,6 @@ const D2Sources: {
       93061497, // VS Gravitic Arrest
       1762785662, // VS Chill Inhibitor
       1762785663, // VS Velocity Baton
-      2344383760, // Eighty-Six
       4232480042, // VS Pyroelectric Propellant
     ],
     sourceHashes: [


### PR DESCRIPTION
Eighty-Six reuses the "Bray Legacy" origin trait but isn't a Vesper's Host weapon. Because Bungie dumped it into the "Random Perks" grab-bag sourceHash (2387628034), the inline origin-trait reclaim added in #881 mis-assigned it to vespershost (and, via extends, vesper/dungeon). Add it to the rule's excludedItems.